### PR TITLE
feat: SandboxError エラークラス階層を実装

### DIFF
--- a/src/core/errors.test.ts
+++ b/src/core/errors.test.ts
@@ -2,278 +2,274 @@
  * SandboxError エラークラス階層のテスト
  * Issue #7: TDD Red Phase - テストを先に作成
  */
-import { describe, it, expect } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import {
-  SandboxError,
-  DockerNotFoundError,
-  DockerTimeoutError,
-  HostExecutionError,
-  ProcessExecutionError,
-  ContainerUseError,
-  EnvironmentUnavailableError,
-  ExecutionTimeoutError,
-  ImagePullError,
+	ContainerUseError,
+	DockerNotFoundError,
+	DockerTimeoutError,
+	EnvironmentUnavailableError,
+	ExecutionTimeoutError,
+	HostExecutionError,
+	ImagePullError,
+	ProcessExecutionError,
+	SandboxError,
 } from "./errors.js";
 
 describe("SandboxError", () => {
-  describe("基底クラス", () => {
-    it("メッセージとcodeで初期化できる", () => {
-      const error = new SandboxError("Test error", { code: "TEST_CODE" });
+	describe("基底クラス", () => {
+		it("メッセージとcodeで初期化できる", () => {
+			const error = new SandboxError("Test error", { code: "TEST_CODE" });
 
-      expect(error.message).toBe("Test error");
-      expect(error.code).toBe("TEST_CODE");
-      expect(error.name).toBe("SandboxError");
-    });
+			expect(error.message).toBe("Test error");
+			expect(error.code).toBe("TEST_CODE");
+			expect(error.name).toBe("SandboxError");
+		});
 
-    it("codeが省略された場合はSANDBOX_ERRORになる", () => {
-      const error = new SandboxError("Test error");
+		it("codeが省略された場合はSANDBOX_ERRORになる", () => {
+			const error = new SandboxError("Test error");
 
-      expect(error.code).toBe("SANDBOX_ERROR");
-    });
+			expect(error.code).toBe("SANDBOX_ERROR");
+		});
 
-    it("detailsを設定できる", () => {
-      const error = new SandboxError("Test error", {
-        code: "TEST_CODE",
-        details: { foo: "bar", count: 42 },
-      });
+		it("detailsを設定できる", () => {
+			const error = new SandboxError("Test error", {
+				code: "TEST_CODE",
+				details: { foo: "bar", count: 42 },
+			});
 
-      expect(error.details).toEqual({ foo: "bar", count: 42 });
-    });
+			expect(error.details).toEqual({ foo: "bar", count: 42 });
+		});
 
-    it("causeを設定できる", () => {
-      const cause = new Error("Original error");
-      const error = new SandboxError("Wrapped error", { cause });
+		it("causeを設定できる", () => {
+			const cause = new Error("Original error");
+			const error = new SandboxError("Wrapped error", { cause });
 
-      expect(error.cause).toBe(cause);
-    });
+			expect(error.cause).toBe(cause);
+		});
 
-    it("toJSON()でJSON形式で取得できる", () => {
-      const error = new SandboxError("Test error", {
-        code: "TEST_CODE",
-        details: { foo: "bar" },
-      });
+		it("toJSON()でJSON形式で取得できる", () => {
+			const error = new SandboxError("Test error", {
+				code: "TEST_CODE",
+				details: { foo: "bar" },
+			});
 
-      const json = error.toJSON();
+			const json = error.toJSON();
 
-      expect(json.name).toBe("SandboxError");
-      expect(json.code).toBe("TEST_CODE");
-      expect(json.message).toBe("Test error");
-      expect(json.details).toEqual({ foo: "bar" });
-      expect(typeof json.stack).toBe("string");
-    });
+			expect(json.name).toBe("SandboxError");
+			expect(json.code).toBe("TEST_CODE");
+			expect(json.message).toBe("Test error");
+			expect(json.details).toEqual({ foo: "bar" });
+			expect(typeof json.stack).toBe("string");
+		});
 
-    it("Errorを継承している", () => {
-      const error = new SandboxError("Test error");
+		it("Errorを継承している", () => {
+			const error = new SandboxError("Test error");
 
-      expect(error).toBeInstanceOf(Error);
-      expect(error).toBeInstanceOf(SandboxError);
-    });
-  });
+			expect(error).toBeInstanceOf(Error);
+			expect(error).toBeInstanceOf(SandboxError);
+		});
+	});
 });
 
 describe("DockerNotFoundError", () => {
-  it("デフォルトメッセージで初期化できる", () => {
-    const error = new DockerNotFoundError();
+	it("デフォルトメッセージで初期化できる", () => {
+		const error = new DockerNotFoundError();
 
-    expect(error.message).toBe("Docker is not installed or not in PATH");
-    expect(error.code).toBe("DOCKER_NOT_FOUND");
-    expect(error.name).toBe("DockerNotFoundError");
-  });
+		expect(error.message).toBe("Docker is not installed or not in PATH");
+		expect(error.code).toBe("DOCKER_NOT_FOUND");
+		expect(error.name).toBe("DockerNotFoundError");
+	});
 
-  it("カスタムメッセージで初期化できる", () => {
-    const error = new DockerNotFoundError("Custom message");
+	it("カスタムメッセージで初期化できる", () => {
+		const error = new DockerNotFoundError("Custom message");
 
-    expect(error.message).toBe("Custom message");
-  });
+		expect(error.message).toBe("Custom message");
+	});
 
-  it("SandboxErrorを継承している", () => {
-    const error = new DockerNotFoundError();
+	it("SandboxErrorを継承している", () => {
+		const error = new DockerNotFoundError();
 
-    expect(error).toBeInstanceOf(SandboxError);
-    expect(error).toBeInstanceOf(DockerNotFoundError);
-  });
+		expect(error).toBeInstanceOf(SandboxError);
+		expect(error).toBeInstanceOf(DockerNotFoundError);
+	});
 });
 
 describe("DockerTimeoutError", () => {
-  it("タイムアウト値でメッセージを生成する", () => {
-    const error = new DockerTimeoutError(5000);
+	it("タイムアウト値でメッセージを生成する", () => {
+		const error = new DockerTimeoutError(5000);
 
-    expect(error.message).toBe("Docker execution timed out after 5000ms");
-    expect(error.code).toBe("DOCKER_TIMEOUT");
-    expect(error.name).toBe("DockerTimeoutError");
-    expect(error.timeout).toBe(5000);
-  });
+		expect(error.message).toBe("Docker execution timed out after 5000ms");
+		expect(error.code).toBe("DOCKER_TIMEOUT");
+		expect(error.name).toBe("DockerTimeoutError");
+		expect(error.timeout).toBe(5000);
+	});
 
-  it("detailsにtimeoutが含まれる", () => {
-    const error = new DockerTimeoutError(3000);
+	it("detailsにtimeoutが含まれる", () => {
+		const error = new DockerTimeoutError(3000);
 
-    expect(error.details).toEqual({ timeout: 3000 });
-  });
+		expect(error.details).toEqual({ timeout: 3000 });
+	});
 
-  it("SandboxErrorを継承している", () => {
-    const error = new DockerTimeoutError(1000);
+	it("SandboxErrorを継承している", () => {
+		const error = new DockerTimeoutError(1000);
 
-    expect(error).toBeInstanceOf(SandboxError);
-    expect(error).toBeInstanceOf(DockerTimeoutError);
-  });
+		expect(error).toBeInstanceOf(SandboxError);
+		expect(error).toBeInstanceOf(DockerTimeoutError);
+	});
 });
 
 describe("HostExecutionError", () => {
-  it("メッセージと終了コードで初期化できる", () => {
-    const error = new HostExecutionError("Command failed", 1);
+	it("メッセージと終了コードで初期化できる", () => {
+		const error = new HostExecutionError("Command failed", 1);
 
-    expect(error.message).toBe("Command failed");
-    expect(error.code).toBe("HOST_EXECUTION_ERROR");
-    expect(error.name).toBe("HostExecutionError");
-    expect(error.exitCode).toBe(1);
-  });
+		expect(error.message).toBe("Command failed");
+		expect(error.code).toBe("HOST_EXECUTION_ERROR");
+		expect(error.name).toBe("HostExecutionError");
+		expect(error.exitCode).toBe(1);
+	});
 
-  it("追加のdetailsを設定できる", () => {
-    const error = new HostExecutionError("Command failed", 127, {
-      command: "npm test",
-    });
+	it("追加のdetailsを設定できる", () => {
+		const error = new HostExecutionError("Command failed", 127, {
+			command: "npm test",
+		});
 
-    expect(error.details).toEqual({ exitCode: 127, command: "npm test" });
-  });
+		expect(error.details).toEqual({ exitCode: 127, command: "npm test" });
+	});
 
-  it("SandboxErrorを継承している", () => {
-    const error = new HostExecutionError("Error", 1);
+	it("SandboxErrorを継承している", () => {
+		const error = new HostExecutionError("Error", 1);
 
-    expect(error).toBeInstanceOf(SandboxError);
-    expect(error).toBeInstanceOf(HostExecutionError);
-  });
+		expect(error).toBeInstanceOf(SandboxError);
+		expect(error).toBeInstanceOf(HostExecutionError);
+	});
 });
 
 describe("ProcessExecutionError", () => {
-  it("メッセージで初期化できる", () => {
-    const error = new ProcessExecutionError("Process failed");
+	it("メッセージで初期化できる", () => {
+		const error = new ProcessExecutionError("Process failed");
 
-    expect(error.message).toBe("Process failed");
-    expect(error.code).toBe("PROCESS_EXECUTION_ERROR");
-    expect(error.name).toBe("ProcessExecutionError");
-  });
+		expect(error.message).toBe("Process failed");
+		expect(error.code).toBe("PROCESS_EXECUTION_ERROR");
+		expect(error.name).toBe("ProcessExecutionError");
+	});
 
-  it("causeとdetailsを設定できる", () => {
-    const cause = new Error("Original error");
-    const error = new ProcessExecutionError("Wrapped error", {
-      cause,
-      details: { command: "echo hello" },
-    });
+	it("causeとdetailsを設定できる", () => {
+		const cause = new Error("Original error");
+		const error = new ProcessExecutionError("Wrapped error", {
+			cause,
+			details: { command: "echo hello" },
+		});
 
-    expect(error.cause).toBe(cause);
-    expect(error.details).toEqual({ command: "echo hello" });
-  });
+		expect(error.cause).toBe(cause);
+		expect(error.details).toEqual({ command: "echo hello" });
+	});
 
-  it("SandboxErrorを継承している", () => {
-    const error = new ProcessExecutionError("Error");
+	it("SandboxErrorを継承している", () => {
+		const error = new ProcessExecutionError("Error");
 
-    expect(error).toBeInstanceOf(SandboxError);
-    expect(error).toBeInstanceOf(ProcessExecutionError);
-  });
+		expect(error).toBeInstanceOf(SandboxError);
+		expect(error).toBeInstanceOf(ProcessExecutionError);
+	});
 });
 
 describe("ContainerUseError", () => {
-  it("メッセージで初期化できる", () => {
-    const error = new ContainerUseError("Container failed");
+	it("メッセージで初期化できる", () => {
+		const error = new ContainerUseError("Container failed");
 
-    expect(error.message).toBe("Container failed");
-    expect(error.code).toBe("CONTAINER_USE_ERROR");
-    expect(error.name).toBe("ContainerUseError");
-  });
+		expect(error.message).toBe("Container failed");
+		expect(error.code).toBe("CONTAINER_USE_ERROR");
+		expect(error.name).toBe("ContainerUseError");
+	});
 
-  it("causeとdetailsを設定できる", () => {
-    const cause = new Error("Original error");
-    const error = new ContainerUseError("Wrapped error", {
-      cause,
-      details: { envId: "test-env" },
-    });
+	it("causeとdetailsを設定できる", () => {
+		const cause = new Error("Original error");
+		const error = new ContainerUseError("Wrapped error", {
+			cause,
+			details: { envId: "test-env" },
+		});
 
-    expect(error.cause).toBe(cause);
-    expect(error.details).toEqual({ envId: "test-env" });
-  });
+		expect(error.cause).toBe(cause);
+		expect(error.details).toEqual({ envId: "test-env" });
+	});
 
-  it("SandboxErrorを継承している", () => {
-    const error = new ContainerUseError("Error");
+	it("SandboxErrorを継承している", () => {
+		const error = new ContainerUseError("Error");
 
-    expect(error).toBeInstanceOf(SandboxError);
-    expect(error).toBeInstanceOf(ContainerUseError);
-  });
+		expect(error).toBeInstanceOf(SandboxError);
+		expect(error).toBeInstanceOf(ContainerUseError);
+	});
 });
 
 describe("EnvironmentUnavailableError", () => {
-  it("環境タイプでメッセージを生成する", () => {
-    const error = new EnvironmentUnavailableError("docker, host");
+	it("環境タイプでメッセージを生成する", () => {
+		const error = new EnvironmentUnavailableError("docker, host");
 
-    expect(error.message).toBe(
-      "No available sandbox environment: tried docker, host"
-    );
-    expect(error.code).toBe("ENVIRONMENT_UNAVAILABLE");
-    expect(error.name).toBe("EnvironmentUnavailableError");
-  });
+		expect(error.message).toBe("No available sandbox environment: tried docker, host");
+		expect(error.code).toBe("ENVIRONMENT_UNAVAILABLE");
+		expect(error.name).toBe("EnvironmentUnavailableError");
+	});
 
-  it("detailsに環境タイプが含まれる", () => {
-    const error = new EnvironmentUnavailableError("container-use");
+	it("detailsに環境タイプが含まれる", () => {
+		const error = new EnvironmentUnavailableError("container-use");
 
-    expect(error.details).toEqual({ triedEnvironments: "container-use" });
-  });
+		expect(error.details).toEqual({ triedEnvironments: "container-use" });
+	});
 
-  it("SandboxErrorを継承している", () => {
-    const error = new EnvironmentUnavailableError("docker");
+	it("SandboxErrorを継承している", () => {
+		const error = new EnvironmentUnavailableError("docker");
 
-    expect(error).toBeInstanceOf(SandboxError);
-    expect(error).toBeInstanceOf(EnvironmentUnavailableError);
-  });
+		expect(error).toBeInstanceOf(SandboxError);
+		expect(error).toBeInstanceOf(EnvironmentUnavailableError);
+	});
 });
 
 describe("ExecutionTimeoutError", () => {
-  it("タイムアウト値でメッセージを生成する", () => {
-    const error = new ExecutionTimeoutError(10000);
+	it("タイムアウト値でメッセージを生成する", () => {
+		const error = new ExecutionTimeoutError(10000);
 
-    expect(error.message).toBe("Execution timed out after 10000ms");
-    expect(error.code).toBe("EXECUTION_TIMEOUT");
-    expect(error.name).toBe("ExecutionTimeoutError");
-    expect(error.timeout).toBe(10000);
-  });
+		expect(error.message).toBe("Execution timed out after 10000ms");
+		expect(error.code).toBe("EXECUTION_TIMEOUT");
+		expect(error.name).toBe("ExecutionTimeoutError");
+		expect(error.timeout).toBe(10000);
+	});
 
-  it("detailsにtimeoutが含まれる", () => {
-    const error = new ExecutionTimeoutError(5000);
+	it("detailsにtimeoutが含まれる", () => {
+		const error = new ExecutionTimeoutError(5000);
 
-    expect(error.details).toEqual({ timeout: 5000 });
-  });
+		expect(error.details).toEqual({ timeout: 5000 });
+	});
 
-  it("SandboxErrorを継承している", () => {
-    const error = new ExecutionTimeoutError(1000);
+	it("SandboxErrorを継承している", () => {
+		const error = new ExecutionTimeoutError(1000);
 
-    expect(error).toBeInstanceOf(SandboxError);
-    expect(error).toBeInstanceOf(ExecutionTimeoutError);
-  });
+		expect(error).toBeInstanceOf(SandboxError);
+		expect(error).toBeInstanceOf(ExecutionTimeoutError);
+	});
 });
 
 describe("ImagePullError", () => {
-  it("イメージ名でメッセージを生成する", () => {
-    const error = new ImagePullError("node:20-alpine", "pull access denied");
+	it("イメージ名でメッセージを生成する", () => {
+		const error = new ImagePullError("node:20-alpine", "pull access denied");
 
-    expect(error.message).toBe(
-      "Failed to pull Docker image: node:20-alpine"
-    );
-    expect(error.code).toBe("IMAGE_PULL_ERROR");
-    expect(error.name).toBe("ImagePullError");
-    expect(error.image).toBe("node:20-alpine");
-  });
+		expect(error.message).toBe("Failed to pull Docker image: node:20-alpine");
+		expect(error.code).toBe("IMAGE_PULL_ERROR");
+		expect(error.name).toBe("ImagePullError");
+		expect(error.image).toBe("node:20-alpine");
+	});
 
-  it("detailsにimageとstderrが含まれる", () => {
-    const error = new ImagePullError("alpine:latest", "network error");
+	it("detailsにimageとstderrが含まれる", () => {
+		const error = new ImagePullError("alpine:latest", "network error");
 
-    expect(error.details).toEqual({
-      image: "alpine:latest",
-      stderr: "network error",
-    });
-  });
+		expect(error.details).toEqual({
+			image: "alpine:latest",
+			stderr: "network error",
+		});
+	});
 
-  it("SandboxErrorを継承している", () => {
-    const error = new ImagePullError("test", "error");
+	it("SandboxErrorを継承している", () => {
+		const error = new ImagePullError("test", "error");
 
-    expect(error).toBeInstanceOf(SandboxError);
-    expect(error).toBeInstanceOf(ImagePullError);
-  });
+		expect(error).toBeInstanceOf(SandboxError);
+		expect(error).toBeInstanceOf(ImagePullError);
+	});
 });

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -18,21 +18,21 @@
  * SandboxErrorのコンストラクタオプション
  */
 export interface SandboxErrorOptions {
-  /**
-   * エラーコード
-   * @default "SANDBOX_ERROR"
-   */
-  code?: string;
+	/**
+	 * エラーコード
+	 * @default "SANDBOX_ERROR"
+	 */
+	code?: string;
 
-  /**
-   * 追加の詳細情報
-   */
-  details?: Record<string, unknown>;
+	/**
+	 * 追加の詳細情報
+	 */
+	details?: Record<string, unknown>;
 
-  /**
-   * 原因となったエラー
-   */
-  cause?: unknown;
+	/**
+	 * 原因となったエラー
+	 */
+	cause?: unknown;
 }
 
 /**
@@ -47,40 +47,40 @@ export interface SandboxErrorOptions {
  * ```
  */
 export class SandboxError extends Error {
-  /**
-   * エラーコード
-   */
-  readonly code: string;
+	/**
+	 * エラーコード
+	 */
+	readonly code: string;
 
-  /**
-   * 追加の詳細情報
-   */
-  readonly details?: Record<string, unknown>;
+	/**
+	 * 追加の詳細情報
+	 */
+	readonly details?: Record<string, unknown>;
 
-  constructor(message: string, options?: SandboxErrorOptions) {
-    super(message, { cause: options?.cause });
-    this.name = "SandboxError";
-    this.code = options?.code ?? "SANDBOX_ERROR";
-    this.details = options?.details;
+	constructor(message: string, options?: SandboxErrorOptions) {
+		super(message, { cause: options?.cause });
+		this.name = "SandboxError";
+		this.code = options?.code ?? "SANDBOX_ERROR";
+		this.details = options?.details;
 
-    // スタックトレースを適切に設定
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, this.constructor);
-    }
-  }
+		// スタックトレースを適切に設定
+		if (Error.captureStackTrace) {
+			Error.captureStackTrace(this, this.constructor);
+		}
+	}
 
-  /**
-   * エラー情報をJSON形式で取得
-   */
-  toJSON(): Record<string, unknown> {
-    return {
-      name: this.name,
-      code: this.code,
-      message: this.message,
-      details: this.details,
-      stack: this.stack,
-    };
-  }
+	/**
+	 * エラー情報をJSON形式で取得
+	 */
+	toJSON(): Record<string, unknown> {
+		return {
+			name: this.name,
+			code: this.code,
+			message: this.message,
+			details: this.details,
+			stack: this.stack,
+		};
+	}
 }
 
 /**
@@ -94,12 +94,12 @@ export class SandboxError extends Error {
  * ```
  */
 export class DockerNotFoundError extends SandboxError {
-  constructor(message = "Docker is not installed or not in PATH") {
-    super(message, {
-      code: "DOCKER_NOT_FOUND",
-    });
-    this.name = "DockerNotFoundError";
-  }
+	constructor(message = "Docker is not installed or not in PATH") {
+		super(message, {
+			code: "DOCKER_NOT_FOUND",
+		});
+		this.name = "DockerNotFoundError";
+	}
 }
 
 /**
@@ -111,19 +111,19 @@ export class DockerNotFoundError extends SandboxError {
  * ```
  */
 export class DockerTimeoutError extends SandboxError {
-  /**
-   * タイムアウト時間（ミリ秒）
-   */
-  readonly timeout: number;
+	/**
+	 * タイムアウト時間（ミリ秒）
+	 */
+	readonly timeout: number;
 
-  constructor(timeout: number) {
-    super(`Docker execution timed out after ${timeout}ms`, {
-      code: "DOCKER_TIMEOUT",
-      details: { timeout },
-    });
-    this.name = "DockerTimeoutError";
-    this.timeout = timeout;
-  }
+	constructor(timeout: number) {
+		super(`Docker execution timed out after ${timeout}ms`, {
+			code: "DOCKER_TIMEOUT",
+			details: { timeout },
+		});
+		this.name = "DockerTimeoutError";
+		this.timeout = timeout;
+	}
 }
 
 /**
@@ -135,23 +135,19 @@ export class DockerTimeoutError extends SandboxError {
  * ```
  */
 export class HostExecutionError extends SandboxError {
-  /**
-   * コマンドの終了コード
-   */
-  readonly exitCode: number;
+	/**
+	 * コマンドの終了コード
+	 */
+	readonly exitCode: number;
 
-  constructor(
-    message: string,
-    exitCode: number,
-    additionalDetails?: Record<string, unknown>
-  ) {
-    super(message, {
-      code: "HOST_EXECUTION_ERROR",
-      details: { exitCode, ...additionalDetails },
-    });
-    this.name = "HostExecutionError";
-    this.exitCode = exitCode;
-  }
+	constructor(message: string, exitCode: number, additionalDetails?: Record<string, unknown>) {
+		super(message, {
+			code: "HOST_EXECUTION_ERROR",
+			details: { exitCode, ...additionalDetails },
+		});
+		this.name = "HostExecutionError";
+		this.exitCode = exitCode;
+	}
 }
 
 /**
@@ -166,19 +162,19 @@ export class HostExecutionError extends SandboxError {
  * ```
  */
 export class ProcessExecutionError extends SandboxError {
-  constructor(
-    message: string,
-    options?: {
-      cause?: unknown;
-      details?: Record<string, unknown>;
-    }
-  ) {
-    super(message, {
-      code: "PROCESS_EXECUTION_ERROR",
-      ...options,
-    });
-    this.name = "ProcessExecutionError";
-  }
+	constructor(
+		message: string,
+		options?: {
+			cause?: unknown;
+			details?: Record<string, unknown>;
+		},
+	) {
+		super(message, {
+			code: "PROCESS_EXECUTION_ERROR",
+			...options,
+		});
+		this.name = "ProcessExecutionError";
+	}
 }
 
 /**
@@ -193,19 +189,19 @@ export class ProcessExecutionError extends SandboxError {
  * ```
  */
 export class ContainerUseError extends SandboxError {
-  constructor(
-    message: string,
-    options?: {
-      cause?: unknown;
-      details?: Record<string, unknown>;
-    }
-  ) {
-    super(message, {
-      code: "CONTAINER_USE_ERROR",
-      ...options,
-    });
-    this.name = "ContainerUseError";
-  }
+	constructor(
+		message: string,
+		options?: {
+			cause?: unknown;
+			details?: Record<string, unknown>;
+		},
+	) {
+		super(message, {
+			code: "CONTAINER_USE_ERROR",
+			...options,
+		});
+		this.name = "ContainerUseError";
+	}
 }
 
 /**
@@ -217,13 +213,13 @@ export class ContainerUseError extends SandboxError {
  * ```
  */
 export class EnvironmentUnavailableError extends SandboxError {
-  constructor(triedEnvironments: string) {
-    super(`No available sandbox environment: tried ${triedEnvironments}`, {
-      code: "ENVIRONMENT_UNAVAILABLE",
-      details: { triedEnvironments },
-    });
-    this.name = "EnvironmentUnavailableError";
-  }
+	constructor(triedEnvironments: string) {
+		super(`No available sandbox environment: tried ${triedEnvironments}`, {
+			code: "ENVIRONMENT_UNAVAILABLE",
+			details: { triedEnvironments },
+		});
+		this.name = "EnvironmentUnavailableError";
+	}
 }
 
 /**
@@ -235,19 +231,19 @@ export class EnvironmentUnavailableError extends SandboxError {
  * ```
  */
 export class ExecutionTimeoutError extends SandboxError {
-  /**
-   * タイムアウト時間（ミリ秒）
-   */
-  readonly timeout: number;
+	/**
+	 * タイムアウト時間（ミリ秒）
+	 */
+	readonly timeout: number;
 
-  constructor(timeout: number) {
-    super(`Execution timed out after ${timeout}ms`, {
-      code: "EXECUTION_TIMEOUT",
-      details: { timeout },
-    });
-    this.name = "ExecutionTimeoutError";
-    this.timeout = timeout;
-  }
+	constructor(timeout: number) {
+		super(`Execution timed out after ${timeout}ms`, {
+			code: "EXECUTION_TIMEOUT",
+			details: { timeout },
+		});
+		this.name = "ExecutionTimeoutError";
+		this.timeout = timeout;
+	}
 }
 
 /**
@@ -259,17 +255,17 @@ export class ExecutionTimeoutError extends SandboxError {
  * ```
  */
 export class ImagePullError extends SandboxError {
-  /**
-   * イメージ名
-   */
-  readonly image: string;
+	/**
+	 * イメージ名
+	 */
+	readonly image: string;
 
-  constructor(image: string, stderr: string) {
-    super(`Failed to pull Docker image: ${image}`, {
-      code: "IMAGE_PULL_ERROR",
-      details: { image, stderr },
-    });
-    this.name = "ImagePullError";
-    this.image = image;
-  }
+	constructor(image: string, stderr: string) {
+		super(`Failed to pull Docker image: ${image}`, {
+			code: "IMAGE_PULL_ERROR",
+			details: { image, stderr },
+		});
+		this.name = "ImagePullError";
+		this.image = image;
+	}
 }


### PR DESCRIPTION
## 概要

サンドボックス関連エラーの基底クラスと個別エラークラスを実装しました。

Closes #7

## 変更内容

### 新規ファイル

- `src/core/errors.ts` - エラークラス定義（271行）
- `src/core/errors.test.ts` - 単体テスト（275行）

### クラス階層

```
Error
└── SandboxError
    ├── DockerNotFoundError
    ├── DockerTimeoutError
    ├── HostExecutionError
    ├── ProcessExecutionError
    ├── ContainerUseError
    ├── EnvironmentUnavailableError
    ├── ExecutionTimeoutError
    └── ImagePullError
```

### 機能

- `SandboxError` 基底クラス with `code`, `details`, `toJSON()`
- 全個別エラークラス実装
- JSDocコメント付き
- 30テストケース（全テスト通過）

## テスト結果

```
 30 pass
 0 fail
 67 expect() calls
```

全プロジェクトテスト：139テスト通過、リグレッションなし

## 関連設計書

- `docs/designs/detailed/追加仕様/共通/型定義・共通処理設計書.md` - セクション4