### PR TITLE
feat: LogStreamer 実装 (F-008)

### DIFF
--- a/src/core/log-streamer.test.ts
+++ b/src/core/log-streamer.test.ts
@@ -93,9 +93,7 @@ describe("LogStreamer", () => {
 				follow: false,
 			});
 
-			await expect(
-				streamer.stream(() => {}),
-			).rejects.toThrow();
+			await expect(streamer.stream(() => {})).rejects.toThrow();
 		});
 	});
 
@@ -149,9 +147,11 @@ describe("LogStreamer", () => {
 			});
 
 			let streamEnded = false;
-			const streamPromise = streamer.stream(() => {}).then(() => {
-				streamEnded = true;
-			});
+			const streamPromise = streamer
+				.stream(() => {})
+				.then(() => {
+					streamEnded = true;
+				});
 
 			// 即座に停止
 			streamer.stop();
@@ -283,9 +283,7 @@ describe("LogStreamer", () => {
 				baseDir: TEST_BASE_DIR,
 			});
 
-			expect(streamer.getLogPath()).toBe(
-				join(TEST_BASE_DIR, TEST_TASK_ID, "output.log"),
-			);
+			expect(streamer.getLogPath()).toBe(join(TEST_BASE_DIR, TEST_TASK_ID, "output.log"));
 		});
 	});
 });

--- a/src/core/log-streamer.ts
+++ b/src/core/log-streamer.ts
@@ -71,11 +71,7 @@ export class LogStreamer {
 
 	constructor(config: LogStreamerConfig) {
 		this.taskId = config.taskId;
-		this.logPath = join(
-			config.baseDir ?? ".agent",
-			config.taskId,
-			"output.log",
-		);
+		this.logPath = join(config.baseDir ?? ".agent", config.taskId, "output.log");
 		this.follow = config.follow ?? false;
 		this.pollInterval = config.pollInterval ?? 100;
 		this.lines = config.lines;
@@ -139,9 +135,7 @@ export class LogStreamer {
 		const content = await file.text();
 		const allLines = content.split("\n").filter((line) => line !== "");
 
-		const linesToReturn = this.lines
-			? allLines.slice(-this.lines)
-			: allLines;
+		const linesToReturn = this.lines ? allLines.slice(-this.lines) : allLines;
 
 		for (const line of linesToReturn) {
 			callback(line);
@@ -151,23 +145,16 @@ export class LogStreamer {
 	/**
 	 * 継続監視モード（ポーリング）
 	 */
-	private async streamFollow(
-		callback: (line: string) => void,
-		signal: AbortSignal,
-	): Promise<void> {
+	private async streamFollow(callback: (line: string) => void, signal: AbortSignal): Promise<void> {
 		let lastPosition = 0;
 
 		// 初回読み取り
 		const file = Bun.file(this.logPath);
 		const initialContent = await file.text();
-		const initialLines = initialContent
-			.split("\n")
-			.filter((line) => line !== "");
+		const initialLines = initialContent.split("\n").filter((line) => line !== "");
 
 		// lines オプションがある場合は最後のN行のみ
-		const linesToEmit = this.lines
-			? initialLines.slice(-this.lines)
-			: initialLines;
+		const linesToEmit = this.lines ? initialLines.slice(-this.lines) : initialLines;
 
 		for (const line of linesToEmit) {
 			callback(line);
@@ -189,9 +176,7 @@ export class LogStreamer {
 			if (currentContent.length > lastPosition) {
 				// 新しいコンテンツを抽出
 				const newContent = currentContent.slice(lastPosition);
-				const newLines = newContent
-					.split("\n")
-					.filter((line) => line !== "");
+				const newLines = newContent.split("\n").filter((line) => line !== "");
 
 				for (const line of newLines) {
 					callback(line);


### PR DESCRIPTION
## 概要

ログファイルをリアルタイムで読み取る `LogStreamer` クラスを実装しました。

Closes #17

## 変更内容

### 新規ファイル
- `src/core/log-streamer.ts` (196行) - LogStreamer クラス
- `src/core/log-streamer.test.ts` (289行) - 単体テスト（14テストケース）

### 機能
- `stream(callback)` - ログファイルを読み取り、各行をコールバックに渡す
- `stop()` - リアルタイム監視を停止
- `getLogPath()` - 監視対象のログファイルパスを取得

### オプション
- `follow` - リアルタイム監視モード（デフォルト: false）
- `pollInterval` - ポーリング間隔（デフォルト: 100ms）
- `lines` - 表示する最後のN行

## 使用例

```typescript
const streamer = new LogStreamer({
  taskId: "task-42-20260124-123456",
  follow: true,
});

await streamer.stream((line) => {
  console.log(line);
});

// Ctrl+C で停止
process.on("SIGINT", () => streamer.stop());
```

## テスト結果

- 全302テスト通過（14テスト追加）
- TypeScript型チェック通過
- Biome lint/format通過