### PR TITLE
feat: F-011 Issue依存関係管理機能実装

### DIFF
--- a/src/input/issue-dependency-resolver.test.ts
+++ b/src/input/issue-dependency-resolver.test.ts
@@ -1,0 +1,440 @@
+import { beforeEach, describe, expect, it, type Mock, mock } from "bun:test";
+import { CircularDependencyError } from "../core/errors.js";
+import type { ProcessExecutor, ProcessResult } from "../core/process-executor.js";
+import { IssueDependencyResolver } from "./issue-dependency-resolver.js";
+
+describe("IssueDependencyResolver", () => {
+	let mockExecutor: ProcessExecutor;
+	let spawnMock: Mock<(cmd: string, args: string[]) => Promise<ProcessResult>>;
+
+	beforeEach(() => {
+		spawnMock = mock(() => Promise.resolve({ stdout: "", stderr: "", exitCode: 0 }));
+		mockExecutor = {
+			spawn: spawnMock,
+		};
+	});
+
+	describe("constructor", () => {
+		it("デフォルトのProcessExecutorで初期化できる", () => {
+			const resolver = new IssueDependencyResolver();
+			expect(resolver).toBeInstanceOf(IssueDependencyResolver);
+		});
+
+		it("カスタムProcessExecutorで初期化できる", () => {
+			const resolver = new IssueDependencyResolver(mockExecutor);
+			expect(resolver).toBeInstanceOf(IssueDependencyResolver);
+		});
+	});
+
+	describe("getDependencies", () => {
+		it("依存関係を正しく取得する", async () => {
+			let callCount = 0;
+			spawnMock.mockImplementation(() => {
+				callCount++;
+				switch (callCount) {
+					case 1: // blocked_by
+						return Promise.resolve({
+							stdout: "41\n43",
+							stderr: "",
+							exitCode: 0,
+						});
+					case 2: // blocking
+						return Promise.resolve({ stdout: "45", stderr: "", exitCode: 0 });
+					case 3: // issue view
+						return Promise.resolve({
+							stdout: JSON.stringify({ state: "OPEN" }),
+							stderr: "",
+							exitCode: 0,
+						});
+					default:
+						return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+				}
+			});
+
+			const resolver = new IssueDependencyResolver(mockExecutor);
+			const result = await resolver.getDependencies(42);
+
+			expect(result).toEqual({
+				issueNumber: 42,
+				blockedBy: [41, 43],
+				blocking: [45],
+				state: "open",
+			});
+		});
+
+		it("依存関係がない場合は空配列を返す", async () => {
+			let callCount = 0;
+			spawnMock.mockImplementation(() => {
+				callCount++;
+				if (callCount <= 2) {
+					return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+				}
+				return Promise.resolve({
+					stdout: JSON.stringify({ state: "OPEN" }),
+					stderr: "",
+					exitCode: 0,
+				});
+			});
+
+			const resolver = new IssueDependencyResolver(mockExecutor);
+			const result = await resolver.getDependencies(42);
+
+			expect(result.blockedBy).toEqual([]);
+			expect(result.blocking).toEqual([]);
+		});
+
+		it("closedのIssueを正しく判定する", async () => {
+			let callCount = 0;
+			spawnMock.mockImplementation(() => {
+				callCount++;
+				if (callCount <= 2) {
+					return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+				}
+				return Promise.resolve({
+					stdout: JSON.stringify({ state: "CLOSED" }),
+					stderr: "",
+					exitCode: 0,
+				});
+			});
+
+			const resolver = new IssueDependencyResolver(mockExecutor);
+			const result = await resolver.getDependencies(42);
+
+			expect(result.state).toBe("closed");
+		});
+
+		it("API失敗時はデフォルト値を使用する", async () => {
+			spawnMock.mockImplementation(() =>
+				Promise.resolve({ stdout: "", stderr: "error", exitCode: 1 }),
+			);
+
+			const resolver = new IssueDependencyResolver(mockExecutor);
+			const result = await resolver.getDependencies(42);
+
+			expect(result.blockedBy).toEqual([]);
+			expect(result.blocking).toEqual([]);
+			expect(result.state).toBe("open");
+		});
+	});
+
+	describe("resolveOrder", () => {
+		it("空配列は空配列を返す", async () => {
+			const resolver = new IssueDependencyResolver(mockExecutor);
+			const result = await resolver.resolveOrder([]);
+
+			expect(result).toEqual([]);
+		});
+
+		it("単一Issueはそのまま返す", async () => {
+			const resolver = new IssueDependencyResolver(mockExecutor);
+			const result = await resolver.resolveOrder([42]);
+
+			expect(result).toEqual([42]);
+		});
+
+		it("依存関係に基づいてソートする", async () => {
+			// Issue 43 -> 42 -> 44 の依存関係
+			// 43は依存なし、42は43に依存、44は42に依存
+			const mockDeps: Record<number, { blockedBy: number[]; blocking: number[] }> = {
+				42: { blockedBy: [43], blocking: [44] },
+				43: { blockedBy: [], blocking: [42] },
+				44: { blockedBy: [42], blocking: [] },
+			};
+
+			spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+				// blocked_by または blocking のAPI呼び出しからIssue番号を抽出
+				const issueMatch = args[1]?.match(/issues\/(\d+)/);
+				if (issueMatch) {
+					const issueNum = Number(issueMatch[1]);
+					const deps = mockDeps[issueNum] ?? { blockedBy: [], blocking: [] };
+
+					if (args[1]?.includes("blocked_by")) {
+						return Promise.resolve({
+							stdout: deps.blockedBy.join("\n"),
+							stderr: "",
+							exitCode: 0,
+						});
+					}
+					if (args[1]?.includes("blocking")) {
+						return Promise.resolve({
+							stdout: deps.blocking.join("\n"),
+							stderr: "",
+							exitCode: 0,
+						});
+					}
+				}
+
+				// issue view コマンド
+				return Promise.resolve({
+					stdout: JSON.stringify({ state: "OPEN" }),
+					stderr: "",
+					exitCode: 0,
+				});
+			});
+
+			const resolver = new IssueDependencyResolver(mockExecutor);
+			const result = await resolver.resolveOrder([42, 43, 44]);
+
+			// 43 -> 42 -> 44 の順序
+			expect(result.indexOf(43)).toBeLessThan(result.indexOf(42));
+			expect(result.indexOf(42)).toBeLessThan(result.indexOf(44));
+		});
+
+		it("依存関係がない場合は番号順でソートする", async () => {
+			// 依存関係なし
+			spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+				if (args[1]?.includes("blocked_by") || args[1]?.includes("blocking")) {
+					return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+				}
+				return Promise.resolve({
+					stdout: JSON.stringify({ state: "OPEN" }),
+					stderr: "",
+					exitCode: 0,
+				});
+			});
+
+			const resolver = new IssueDependencyResolver(mockExecutor);
+			const result = await resolver.resolveOrder([44, 42, 43]);
+
+			// 番号順
+			expect(result).toEqual([42, 43, 44]);
+		});
+	});
+
+	describe("detectCircularDependency", () => {
+		it("循環依存を検出してエラーをスローする", async () => {
+			// 42 -> 43 -> 44 -> 42 の循環
+			const mockDeps: Record<number, { blockedBy: number[]; blocking: number[] }> = {
+				42: { blockedBy: [44], blocking: [43] },
+				43: { blockedBy: [42], blocking: [44] },
+				44: { blockedBy: [43], blocking: [42] },
+			};
+
+			spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+				const issueMatch = args[1]?.match(/issues\/(\d+)/);
+				if (issueMatch) {
+					const issueNum = Number(issueMatch[1]);
+					const deps = mockDeps[issueNum] ?? { blockedBy: [], blocking: [] };
+
+					if (args[1]?.includes("blocked_by")) {
+						return Promise.resolve({
+							stdout: deps.blockedBy.join("\n"),
+							stderr: "",
+							exitCode: 0,
+						});
+					}
+					if (args[1]?.includes("blocking")) {
+						return Promise.resolve({
+							stdout: deps.blocking.join("\n"),
+							stderr: "",
+							exitCode: 0,
+						});
+					}
+				}
+				return Promise.resolve({
+					stdout: JSON.stringify({ state: "OPEN" }),
+					stderr: "",
+					exitCode: 0,
+				});
+			});
+
+			const resolver = new IssueDependencyResolver(mockExecutor);
+
+			await expect(resolver.resolveOrder([42, 43, 44])).rejects.toThrow(CircularDependencyError);
+		});
+
+		it("循環依存のエラーメッセージに循環パスが含まれる", async () => {
+			const mockDeps: Record<number, { blockedBy: number[]; blocking: number[] }> = {
+				42: { blockedBy: [43], blocking: [] },
+				43: { blockedBy: [42], blocking: [] },
+			};
+
+			spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+				const issueMatch = args[1]?.match(/issues\/(\d+)/);
+				if (issueMatch) {
+					const issueNum = Number(issueMatch[1]);
+					const deps = mockDeps[issueNum] ?? { blockedBy: [], blocking: [] };
+
+					if (args[1]?.includes("blocked_by")) {
+						return Promise.resolve({
+							stdout: deps.blockedBy.join("\n"),
+							stderr: "",
+							exitCode: 0,
+						});
+					}
+					if (args[1]?.includes("blocking")) {
+						return Promise.resolve({
+							stdout: deps.blocking.join("\n"),
+							stderr: "",
+							exitCode: 0,
+						});
+					}
+				}
+				return Promise.resolve({
+					stdout: JSON.stringify({ state: "OPEN" }),
+					stderr: "",
+					exitCode: 0,
+				});
+			});
+
+			const resolver = new IssueDependencyResolver(mockExecutor);
+
+			try {
+				await resolver.resolveOrder([42, 43]);
+				expect.unreachable("Should throw CircularDependencyError");
+			} catch (error) {
+				expect(error).toBeInstanceOf(CircularDependencyError);
+				expect((error as CircularDependencyError).message).toContain("循環依存");
+			}
+		});
+	});
+
+	describe("checkDependenciesCompleted", () => {
+		it("依存がすべて完了している場合はtrueを返す", async () => {
+			let callCount = 0;
+			spawnMock.mockImplementation(() => {
+				callCount++;
+				if (callCount === 1) {
+					// blocked_by for issue 42
+					return Promise.resolve({ stdout: "41", stderr: "", exitCode: 0 });
+				}
+				if (callCount === 2) {
+					// blocking for issue 42
+					return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+				}
+				if (callCount === 3) {
+					// state for issue 42
+					return Promise.resolve({
+						stdout: JSON.stringify({ state: "OPEN" }),
+						stderr: "",
+						exitCode: 0,
+					});
+				}
+				// 依存Issue 41のblocked_by
+				if (callCount === 4) {
+					return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+				}
+				// 依存Issue 41のblocking
+				if (callCount === 5) {
+					return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+				}
+				// 依存Issue 41の状態 -> CLOSED
+				return Promise.resolve({
+					stdout: JSON.stringify({ state: "CLOSED" }),
+					stderr: "",
+					exitCode: 0,
+				});
+			});
+
+			const resolver = new IssueDependencyResolver(mockExecutor);
+			const result = await resolver.checkDependenciesCompleted(42);
+
+			expect(result).toBe(true);
+		});
+
+		it("依存が未完了の場合はfalseを返す", async () => {
+			let callCount = 0;
+			spawnMock.mockImplementation(() => {
+				callCount++;
+				if (callCount === 1) {
+					return Promise.resolve({ stdout: "41", stderr: "", exitCode: 0 });
+				}
+				if (callCount === 2) {
+					return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+				}
+				// すべてOPEN状態
+				return Promise.resolve({
+					stdout: JSON.stringify({ state: "OPEN" }),
+					stderr: "",
+					exitCode: 0,
+				});
+			});
+
+			const resolver = new IssueDependencyResolver(mockExecutor);
+			const result = await resolver.checkDependenciesCompleted(42);
+
+			expect(result).toBe(false);
+		});
+
+		it("依存がない場合はtrueを返す", async () => {
+			spawnMock.mockImplementation(() =>
+				Promise.resolve({
+					stdout: "",
+					stderr: "",
+					exitCode: 0,
+				}),
+			);
+
+			const resolver = new IssueDependencyResolver(mockExecutor);
+			const result = await resolver.checkDependenciesCompleted(42);
+
+			expect(result).toBe(true);
+		});
+	});
+
+	describe("generateDependencyReport", () => {
+		it("依存関係レポートを生成する", async () => {
+			let callCount = 0;
+			spawnMock.mockImplementation(() => {
+				callCount++;
+				if (callCount === 1) {
+					// blocked_by for issue 42
+					return Promise.resolve({ stdout: "41", stderr: "", exitCode: 0 });
+				}
+				if (callCount === 2) {
+					// blocking for issue 42
+					return Promise.resolve({ stdout: "45", stderr: "", exitCode: 0 });
+				}
+				if (callCount === 3) {
+					// state for issue 42
+					return Promise.resolve({
+						stdout: JSON.stringify({ state: "OPEN" }),
+						stderr: "",
+						exitCode: 0,
+					});
+				}
+				// 依存Issue 41の情報
+				if (callCount <= 6) {
+					if (callCount === 6) {
+						return Promise.resolve({
+							stdout: JSON.stringify({ state: "CLOSED" }),
+							stderr: "",
+							exitCode: 0,
+						});
+					}
+					return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+				}
+				return Promise.resolve({
+					stdout: JSON.stringify({ state: "OPEN" }),
+					stderr: "",
+					exitCode: 0,
+				});
+			});
+
+			const resolver = new IssueDependencyResolver(mockExecutor);
+			const report = await resolver.generateDependencyReport(42);
+
+			expect(report).toContain("Issue #42 の依存関係:");
+			expect(report).toContain("依存元（blockedBy）:");
+			expect(report).toContain("#41");
+			expect(report).toContain("ブロック先（blocking）:");
+			expect(report).toContain("#45");
+		});
+
+		it("依存がない場合はなしと表示する", async () => {
+			spawnMock.mockImplementation(() =>
+				Promise.resolve({
+					stdout: "",
+					stderr: "",
+					exitCode: 0,
+				}),
+			);
+
+			const resolver = new IssueDependencyResolver(mockExecutor);
+			const report = await resolver.generateDependencyReport(42);
+
+			expect(report).toContain("なし");
+			expect(report).toContain("すべての依存Issueが完了");
+		});
+	});
+});

--- a/src/input/issue-dependency-resolver.ts
+++ b/src/input/issue-dependency-resolver.ts
@@ -1,0 +1,298 @@
+import { BunProcessExecutor } from "../core/bun-process-executor.js";
+import { CircularDependencyError } from "../core/errors.js";
+import { logger } from "../core/logger.js";
+import type { ProcessExecutor } from "../core/process-executor.js";
+
+export interface DependencyNode {
+	issueNumber: number;
+	blockedBy: number[];
+	blocking: number[];
+	state: "open" | "closed";
+}
+
+export class IssueDependencyResolver {
+	private readonly executor: ProcessExecutor;
+
+	constructor(executor: ProcessExecutor = new BunProcessExecutor()) {
+		this.executor = executor;
+	}
+
+	async resolveOrder(issueNumbers: number[]): Promise<number[]> {
+		if (issueNumbers.length === 0) {
+			return [];
+		}
+
+		if (issueNumbers.length === 1) {
+			return issueNumbers;
+		}
+
+		logger.info(`${issueNumbers.length}件のIssueの依存関係を解析中...`);
+
+		const graph = await this.buildDependencyGraph(issueNumbers);
+		this.detectCircularDependency(graph);
+		const sorted = this.topologicalSort(graph);
+
+		logger.info(`実行順序: ${sorted.map((n) => `#${n}`).join(" -> ")}`);
+
+		return sorted;
+	}
+
+	async getDependencies(issueNumber: number): Promise<DependencyNode> {
+		const blockedByResult = await this.executor.spawn("gh", [
+			"api",
+			`repos/{owner}/{repo}/issues/${issueNumber}/dependencies/blocked_by`,
+			"--jq",
+			".[].number",
+		]);
+
+		const blockingResult = await this.executor.spawn("gh", [
+			"api",
+			`repos/{owner}/{repo}/issues/${issueNumber}/dependencies/blocking`,
+			"--jq",
+			".[].number",
+		]);
+
+		const blockedBy =
+			blockedByResult.exitCode === 0 && blockedByResult.stdout.trim()
+				? blockedByResult.stdout
+						.trim()
+						.split("\n")
+						.map(Number)
+						.filter((n: number) => !Number.isNaN(n))
+				: [];
+
+		const blocking =
+			blockingResult.exitCode === 0 && blockingResult.stdout.trim()
+				? blockingResult.stdout
+						.trim()
+						.split("\n")
+						.map(Number)
+						.filter((n: number) => !Number.isNaN(n))
+				: [];
+
+		const issueResult = await this.executor.spawn("gh", [
+			"issue",
+			"view",
+			String(issueNumber),
+			"--json",
+			"state",
+		]);
+
+		let state: "open" | "closed" = "open";
+		if (issueResult.exitCode === 0) {
+			try {
+				const issueData = JSON.parse(issueResult.stdout);
+				state = issueData.state?.toLowerCase() === "closed" ? "closed" : "open";
+			} catch {
+				// JSON parse error - use default
+			}
+		}
+
+		return {
+			issueNumber,
+			blockedBy,
+			blocking,
+			state,
+		};
+	}
+
+	async checkDependenciesCompleted(issueNumber: number): Promise<boolean> {
+		const node = await this.getDependencies(issueNumber);
+
+		if (node.blockedBy.length === 0) {
+			return true;
+		}
+
+		const incompleteIssues: number[] = [];
+
+		for (const dep of node.blockedBy) {
+			const depNode = await this.getDependencies(dep);
+			if (depNode.state !== "closed") {
+				incompleteIssues.push(dep);
+				logger.warn(`Issue #${issueNumber} は Issue #${dep} に依存していますが、未完了です。`);
+			}
+		}
+
+		if (incompleteIssues.length > 0) {
+			logger.error(`未完了の依存Issue: ${incompleteIssues.map((n) => `#${n}`).join(", ")}`);
+			return false;
+		}
+
+		return true;
+	}
+
+	async generateDependencyReport(issueNumber: number): Promise<string> {
+		const node = await this.getDependencies(issueNumber);
+		const lines: string[] = [];
+
+		lines.push(`Issue #${issueNumber} の依存関係:`);
+		lines.push("");
+
+		lines.push("  依存元（blockedBy）:");
+		if (node.blockedBy.length === 0) {
+			lines.push("    なし");
+		} else {
+			for (const dep of node.blockedBy) {
+				const depNode = await this.getDependencies(dep);
+				const status = depNode.state === "closed" ? "[closed]" : "[open] <- 未完了";
+				lines.push(`    - #${dep}: ${status}`);
+			}
+		}
+		lines.push("");
+
+		lines.push("  ブロック先（blocking）:");
+		if (node.blocking.length === 0) {
+			lines.push("    なし");
+		} else {
+			for (const dep of node.blocking) {
+				lines.push(`    - #${dep}`);
+			}
+		}
+		lines.push("");
+
+		const completed = await this.checkDependenciesCompleted(issueNumber);
+		const status = completed ? "すべての依存Issueが完了" : "依存Issue未完了";
+		lines.push(`ステータス: ${status}`);
+
+		return lines.join("\n");
+	}
+
+	private async buildDependencyGraph(issueNumbers: number[]): Promise<Map<number, DependencyNode>> {
+		const graph = new Map<number, DependencyNode>();
+
+		for (const issueNumber of issueNumbers) {
+			const node = await this.getDependencies(issueNumber);
+			graph.set(issueNumber, node);
+		}
+
+		return graph;
+	}
+
+	private detectCircularDependency(graph: Map<number, DependencyNode>): void {
+		const visited = new Set<number>();
+		const recursionStack = new Set<number>();
+		const path: number[] = [];
+
+		const dfs = (issueNumber: number): void => {
+			visited.add(issueNumber);
+			recursionStack.add(issueNumber);
+			path.push(issueNumber);
+
+			const node = graph.get(issueNumber);
+			if (!node) {
+				recursionStack.delete(issueNumber);
+				path.pop();
+				return;
+			}
+
+			for (const dep of node.blockedBy) {
+				if (!graph.has(dep)) {
+					continue;
+				}
+
+				if (!visited.has(dep)) {
+					dfs(dep);
+				} else if (recursionStack.has(dep)) {
+					const cycleStartIndex = path.indexOf(dep);
+					const cycle = [...path.slice(cycleStartIndex), dep];
+
+					throw new CircularDependencyError(
+						`循環依存を検出: ${cycle.map((n) => `#${n}`).join(" -> ")}`,
+						{ cycle },
+					);
+				}
+			}
+
+			recursionStack.delete(issueNumber);
+			path.pop();
+		};
+
+		for (const issueNumber of graph.keys()) {
+			if (!visited.has(issueNumber)) {
+				dfs(issueNumber);
+			}
+		}
+	}
+
+	private topologicalSort(graph: Map<number, DependencyNode>): number[] {
+		const inDegree = this.calculateInDegree(graph);
+		const queue = this.getZeroInDegreeNodes(inDegree);
+		return this.processTopologicalQueue(graph, inDegree, queue);
+	}
+
+	private calculateInDegree(graph: Map<number, DependencyNode>): Map<number, number> {
+		const inDegree = new Map<number, number>();
+
+		for (const issueNumber of graph.keys()) {
+			inDegree.set(issueNumber, 0);
+		}
+
+		for (const node of graph.values()) {
+			for (const dep of node.blockedBy) {
+				if (graph.has(dep)) {
+					const current = inDegree.get(node.issueNumber) ?? 0;
+					inDegree.set(node.issueNumber, current + 1);
+				}
+			}
+		}
+
+		return inDegree;
+	}
+
+	private getZeroInDegreeNodes(inDegree: Map<number, number>): number[] {
+		const queue: number[] = [];
+		for (const [issueNumber, degree] of inDegree.entries()) {
+			if (degree === 0) {
+				queue.push(issueNumber);
+			}
+		}
+		return queue;
+	}
+
+	private processTopologicalQueue(
+		graph: Map<number, DependencyNode>,
+		inDegree: Map<number, number>,
+		queue: number[],
+	): number[] {
+		const result: number[] = [];
+
+		while (queue.length > 0) {
+			queue.sort((a, b) => a - b);
+			const issueNumber = queue.shift();
+			if (issueNumber === undefined) {
+				break;
+			}
+			result.push(issueNumber);
+
+			const node = graph.get(issueNumber);
+			if (!node) {
+				continue;
+			}
+
+			this.decrementBlockedInDegree(graph, inDegree, queue, node.blocking);
+		}
+
+		return result;
+	}
+
+	private decrementBlockedInDegree(
+		graph: Map<number, DependencyNode>,
+		inDegree: Map<number, number>,
+		queue: number[],
+		blocking: number[],
+	): void {
+		for (const blocked of blocking) {
+			if (!graph.has(blocked)) {
+				continue;
+			}
+
+			const currentDegree = inDegree.get(blocked) ?? 0;
+			const degree = currentDegree - 1;
+			inDegree.set(blocked, degree);
+
+			if (degree === 0) {
+				queue.push(blocked);
+			}
+		}
+	}
+}


### PR DESCRIPTION
## 概要

Issue間の依存関係を管理し、依存順に実行する機能を実装しました。

Closes #52

## 変更内容

### 新規ファイル
- `src/input/issue-dependency-resolver.ts` - IssueDependencyResolverクラス
- `src/input/issue-dependency-resolver.test.ts` - テストファイル（17テストケース）

### IssueDependencyResolverクラスの機能
- `resolveOrder(issueNumbers)` - トポロジカルソートで実行順序を決定
- `getDependencies(issueNumber)` - GitHub Issue Dependencies APIで依存関係を取得
- `checkDependenciesCompleted(issueNumber)` - 依存Issueの完了状態をチェック
- `generateDependencyReport(issueNumber)` - 依存関係レポートを生成

### アルゴリズム
- **トポロジカルソート**: Kahnのアルゴリズムで依存順にソート
- **循環依存検出**: DFSで循環依存を検出し、CircularDependencyErrorをスロー

### GitHub Issue Dependencies API
```
GET repos/{owner}/{repo}/issues/{issue_number}/dependencies/blocked_by
GET repos/{owner}/{repo}/issues/{issue_number}/dependencies/blocking
```

## テスト結果

17テストケース追加、408テスト全て通過

```
✓ src/input/issue-dependency-resolver.test.ts (17)
  ✓ IssueDependencyResolver (17)
    ✓ constructor (2)
    ✓ getDependencies (4)
    ✓ resolveOrder (4)
    ✓ detectCircularDependency (2)
    ✓ checkDependenciesCompleted (3)
    ✓ generateDependencyReport (2)
```

## 関連設計書
- `docs/designs/detailed/v1.3.0機能/issue-dependency/詳細設計書.md`
- `docs/designs/detailed/v1.3.0機能/issue-dependency/バックエンド設計書.md`

## エラークラス（#49で追加済み）
- `CircularDependencyError` - 循環依存エラー
- `IssueDependencyError` - Issue依存関係エラー

## 次のステップ
CLI統合（`--resolve-deps`, `--ignore-deps`, `--check-deps`オプション）は別PRで実装予定