### PR TITLE
feat: F-015 Tasks System (JSONL形式タスク管理)

### DIFF
--- a/src/core/orch-task-manager.test.ts
+++ b/src/core/orch-task-manager.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, rm } from "node:fs/promises";
+import { OrchTaskManager } from "./orch-task-manager.js";
+
+const testDir = ".test-agent-orch-task";
+
+beforeEach(async () => {
+	await mkdir(testDir, { recursive: true });
+});
+
+afterEach(async () => {
+	await rm(testDir, { recursive: true, force: true });
+});
+
+describe("OrchTaskManager", () => {
+	test("Taskを追加", async () => {
+		const manager = new OrchTaskManager({ enabled: true }, testDir);
+
+		const taskId = await manager.addTask("Add auth", 2);
+
+		expect(taskId).toBe("task-001");
+
+		const tasks = await manager.listTasks();
+		expect(tasks).toHaveLength(1);
+		expect(tasks[0].title).toBe("Add auth");
+		expect(tasks[0].priority).toBe(2);
+		expect(tasks[0].status).toBe("open");
+	});
+
+	test("Task状態を更新", async () => {
+		const manager = new OrchTaskManager({ enabled: true }, testDir);
+
+		const taskId = await manager.addTask("Task 1", 1);
+		await manager.updateStatus(taskId, "in-progress");
+		await manager.updateStatus(taskId, "closed");
+
+		const tasks = await manager.listTasks();
+		expect(tasks[0].status).toBe("closed");
+	});
+
+	test("ブロックされていないTaskを取得", async () => {
+		const manager = new OrchTaskManager({ enabled: true }, testDir);
+
+		const task1 = await manager.addTask("Task 1", 1);
+		await manager.addTask("Task 2", 2, [task1]);
+
+		const ready = await manager.getReadyTasks();
+		expect(ready).toHaveLength(1);
+		expect(ready[0].id).toBe(task1);
+	});
+
+	test("依存タスクが完了したらブロック解除", async () => {
+		const manager = new OrchTaskManager({ enabled: true }, testDir);
+
+		const task1 = await manager.addTask("Task 1", 1);
+		await manager.addTask("Task 2", 2, [task1]);
+
+		let ready = await manager.getReadyTasks();
+		expect(ready).toHaveLength(1);
+		expect(ready[0].id).toBe(task1);
+
+		await manager.updateStatus(task1, "closed");
+
+		ready = await manager.getReadyTasks();
+		expect(ready).toHaveLength(1);
+		expect(ready[0].id).toBe("task-002");
+	});
+
+	test("すべてのTaskが完了しているか確認", async () => {
+		const manager = new OrchTaskManager({ enabled: true }, testDir);
+
+		const task1 = await manager.addTask("Task 1", 1);
+		const task2 = await manager.addTask("Task 2", 2);
+
+		expect(await manager.isAllTasksCompleted()).toBe(false);
+
+		await manager.updateStatus(task1, "closed");
+		expect(await manager.isAllTasksCompleted()).toBe(false);
+
+		await manager.updateStatus(task2, "closed");
+		expect(await manager.isAllTasksCompleted()).toBe(true);
+	});
+
+	test("優先度順にソート", async () => {
+		const manager = new OrchTaskManager({ enabled: true }, testDir);
+
+		await manager.addTask("Low priority", 5);
+		await manager.addTask("High priority", 1);
+		await manager.addTask("Medium priority", 3);
+
+		const tasks = await manager.listTasks();
+		expect(tasks[0].priority).toBe(1);
+		expect(tasks[1].priority).toBe(3);
+		expect(tasks[2].priority).toBe(5);
+	});
+
+	test("Tasksが無効の場合は空配列", async () => {
+		const manager = new OrchTaskManager({ enabled: false }, testDir);
+
+		const taskId = await manager.addTask("Task 1", 1);
+		expect(taskId).toBe("");
+
+		const tasks = await manager.listTasks();
+		expect(tasks).toHaveLength(0);
+	});
+
+	test("deleteTaskでclosedに更新", async () => {
+		const manager = new OrchTaskManager({ enabled: true }, testDir);
+
+		const taskId = await manager.addTask("Task 1", 1);
+		await manager.deleteTask(taskId);
+
+		const tasks = await manager.listTasks();
+		expect(tasks[0].status).toBe("closed");
+	});
+
+	test("タスクが存在しない場合もisAllTasksCompletedはtrue", async () => {
+		const manager = new OrchTaskManager({ enabled: true }, testDir);
+		expect(await manager.isAllTasksCompleted()).toBe(true);
+	});
+
+	test("存在しない依存タスクは警告して無視", async () => {
+		const manager = new OrchTaskManager({ enabled: true }, testDir);
+
+		await manager.addTask("Task 1", 1, ["non-existent-task"]);
+
+		const ready = await manager.getReadyTasks();
+		expect(ready).toHaveLength(1);
+	});
+});

--- a/src/core/orch-task-manager.ts
+++ b/src/core/orch-task-manager.ts
@@ -1,0 +1,167 @@
+import { appendFile, mkdir, readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { logger } from "./logger.js";
+import type { TasksConfig } from "./types.js";
+
+export type OrchTaskStatus = "open" | "in-progress" | "closed";
+
+export interface OrchTask {
+	id: string;
+	title: string;
+	priority: number;
+	status: OrchTaskStatus;
+	blocked_by: string[];
+	created_at: string;
+	updated_at: string;
+}
+
+export class OrchTaskManager {
+	private readonly config: TasksConfig;
+	private readonly tasksPath: string;
+
+	constructor(config: TasksConfig, baseDir: string) {
+		this.config = config;
+		this.tasksPath = join(baseDir, "tasks.jsonl");
+	}
+
+	async loadTasks(): Promise<OrchTask[]> {
+		if (!this.config.enabled) {
+			return [];
+		}
+
+		try {
+			const content = await readFile(this.tasksPath, "utf-8");
+			return this.parseTasks(content);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+				return [];
+			}
+			logger.warn("tasks.jsonlの読み込みに失敗しました。空のtasksとして扱います。");
+			return [];
+		}
+	}
+
+	async addTask(title: string, priority = 3, blockedBy: string[] = []): Promise<string> {
+		if (!this.config.enabled) {
+			logger.warn("Tasksは無効です。");
+			return "";
+		}
+
+		const tasks = await this.loadTasks();
+		const taskId = this.generateTaskId(tasks);
+		const now = new Date().toISOString();
+
+		const task: OrchTask = {
+			id: taskId,
+			title,
+			priority,
+			status: "open",
+			blocked_by: blockedBy,
+			created_at: now,
+			updated_at: now,
+		};
+
+		await this.appendTask(task);
+		logger.info(`Task追加: ${taskId} - ${title}`);
+		return taskId;
+	}
+
+	async getReadyTasks(): Promise<OrchTask[]> {
+		const tasks = await this.loadTasks();
+		return tasks.filter((task) => task.status === "open" && !this.isBlocked(task, tasks));
+	}
+
+	async updateStatus(taskId: string, status: OrchTaskStatus): Promise<void> {
+		const tasks = await this.loadTasks();
+		const task = tasks.find((t) => t.id === taskId);
+
+		if (!task) {
+			logger.warn(`Task ${taskId} が見つかりません`);
+			return;
+		}
+
+		const updatedTask: OrchTask = {
+			...task,
+			status,
+			updated_at: new Date().toISOString(),
+		};
+
+		await this.appendTask(updatedTask);
+		logger.info(`Task状態更新: ${taskId} -> ${status}`);
+	}
+
+	async listTasks(): Promise<OrchTask[]> {
+		return this.loadTasks();
+	}
+
+	async deleteTask(taskId: string): Promise<void> {
+		await this.updateStatus(taskId, "closed");
+	}
+
+	async isAllTasksCompleted(): Promise<boolean> {
+		const tasks = await this.loadTasks();
+		if (tasks.length === 0) {
+			return true;
+		}
+		return tasks.every((task) => task.status === "closed");
+	}
+
+	private parseTasks(content: string): OrchTask[] {
+		const lines = content
+			.trim()
+			.split("\n")
+			.filter((line) => line);
+		const taskMap = new Map<string, OrchTask>();
+
+		for (const line of lines) {
+			try {
+				const task = JSON.parse(line) as OrchTask;
+				taskMap.set(task.id, task);
+			} catch {
+				logger.warn(`不正なJSONL行をスキップ: ${line.substring(0, 50)}...`);
+			}
+		}
+
+		return Array.from(taskMap.values()).sort((a, b) => a.priority - b.priority);
+	}
+
+	private async appendTask(task: OrchTask): Promise<void> {
+		await mkdir(dirname(this.tasksPath), { recursive: true });
+		const line = `${JSON.stringify(task)}\n`;
+		await appendFile(this.tasksPath, line);
+	}
+
+	private generateTaskId(tasks: OrchTask[]): string {
+		let maxNum = 0;
+		for (const task of tasks) {
+			const match = task.id.match(/^task-(\d+)$/);
+			if (match) {
+				const num = Number.parseInt(match[1], 10);
+				if (num > maxNum) {
+					maxNum = num;
+				}
+			}
+		}
+		const nextNum = maxNum + 1;
+		return `task-${String(nextNum).padStart(3, "0")}`;
+	}
+
+	private isBlocked(task: OrchTask, allTasks: OrchTask[]): boolean {
+		if (task.blocked_by.length === 0) {
+			return false;
+		}
+
+		for (const depId of task.blocked_by) {
+			const depTask = allTasks.find((t) => t.id === depId);
+			if (!depTask) {
+				logger.warn(`依存タスク ${depId} が存在しません。依存関係を無視します。`);
+				continue;
+			}
+			if (depTask.status !== "closed") {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -219,6 +219,21 @@ export const StateConfigSchema = z.object({
 });
 
 /**
+ * Tasks設定のzodスキーマ（v1.4.0）
+ *
+ * タスクをJSONL形式で管理する機能（F-015）の設定を定義します。
+ */
+export const TasksConfigSchema = z.object({
+	/**
+	 * Tasksを有効にするか
+	 * @default true
+	 */
+	enabled: z.boolean().default(true),
+});
+
+export type TasksConfig = z.infer<typeof TasksConfigSchema>;
+
+/**
  * Memories設定のzodスキーマ（v1.4.0）
  *
  * セッション間で学習内容を永続化する機能（F-014）の設定を定義します。
@@ -288,6 +303,9 @@ export const ConfigSchema = z.object({
 
 	// 新規: Memories設定（v1.4.0）
 	memories: MemoriesConfigSchema.optional(),
+
+	// 新規: Tasks設定（v1.4.0）
+	tasks: TasksConfigSchema.optional(),
 });
 
 export type Config = z.infer<typeof ConfigSchema>;


### PR DESCRIPTION
## Summary

タスクをJSONL形式で `.agent/tasks.jsonl` に管理し、依存関係を追跡する Tasks System を実装しました。

## Changes

- **OrchTaskManager クラス** (`src/core/orch-task-manager.ts`)
  - タスクの追加・一覧・状態更新機能
  - 依存関係（blocked_by）による実行可能タスクの判定
  - JSONL 追記型ログによる状態履歴管理

- **TasksConfigSchema 型定義** (`src/core/types.ts`)
  - `tasks.enabled` 設定の追加

- **CLI コマンド** (`src/cli.ts`)
  - `orch tools task add <title> -p <priority> --blocked-by <id>` - タスク追加
  - `orch tools task list` - 一覧表示
  - `orch tools task ready` - ブロックされていないタスク表示
  - `orch tools task close <id>` - タスク完了

- **単体テスト** (`src/core/orch-task-manager.test.ts`)
  - 10件のテストケース（全通過）

## Testing

```bash
bun test src/core/orch-task-manager.test.ts  # 10 pass
bun test                                      # 491 pass
bun run typecheck                             # OK
```

## CLI Demo

```bash
orch tools task add "First task" -p 1
orch tools task add "Second task" -p 2 --blocked-by task-001
orch tools task list
orch tools task ready
orch tools task close task-001
```

Closes #63