### PR TITLE
feat: F-016 Session Recording (JSONL形式セッション記録・リプレイ)

### DIFF
--- a/src/core/session-recorder.test.ts
+++ b/src/core/session-recorder.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { readFile, rm } from "node:fs/promises";
+import { SessionRecorder } from "./session-recorder.js";
+
+const testDir = ".test-session-recorder";
+const testFile = `${testDir}/session.jsonl`;
+
+beforeEach(async () => {
+	await rm(testDir, { recursive: true, force: true });
+});
+
+afterEach(async () => {
+	await rm(testDir, { recursive: true, force: true });
+});
+
+describe("SessionRecorder", () => {
+	test("記録を開始するとファイルが作成される", async () => {
+		const recorder = new SessionRecorder(testFile);
+		await recorder.startRecording();
+
+		const content = await readFile(testFile, "utf-8");
+		expect(content).toBe("");
+
+		await recorder.stopRecording();
+	});
+
+	test("イテレーションを記録するとJSONL形式で追記される", async () => {
+		const recorder = new SessionRecorder(testFile);
+		await recorder.startRecording();
+
+		await recorder.recordIteration(1, "planner", "prompt1", "output1", ["plan.ready"]);
+		await recorder.recordIteration(2, "implementer", "prompt2", "output2", ["code.written"]);
+
+		await recorder.stopRecording();
+
+		const content = await readFile(testFile, "utf-8");
+		const lines = content.trim().split("\n");
+
+		expect(lines).toHaveLength(2);
+
+		const record1 = JSON.parse(lines[0]);
+		expect(record1.iteration).toBe(1);
+		expect(record1.hat).toBe("planner");
+		expect(record1.prompt).toBe("prompt1");
+		expect(record1.output).toBe("output1");
+		expect(record1.events).toEqual(["plan.ready"]);
+		expect(record1.timestamp).toBeDefined();
+
+		const record2 = JSON.parse(lines[1]);
+		expect(record2.iteration).toBe(2);
+		expect(record2.hat).toBe("implementer");
+	});
+
+	test("記録開始前にrecordIterationを呼ぶと何も記録されない", async () => {
+		const recorder = new SessionRecorder(testFile);
+
+		await recorder.recordIteration(1, "planner", "prompt", "output", []);
+
+		try {
+			await readFile(testFile, "utf-8");
+			expect(true).toBe(false);
+		} catch (error) {
+			expect((error as NodeJS.ErrnoException).code).toBe("ENOENT");
+		}
+	});
+
+	test("stopRecording後はisRecordingがfalseになる", async () => {
+		const recorder = new SessionRecorder(testFile);
+		await recorder.startRecording();
+		await recorder.recordIteration(1, "planner", "prompt", "output", []);
+		await recorder.stopRecording();
+
+		await recorder.recordIteration(2, "implementer", "prompt2", "output2", []);
+
+		const content = await readFile(testFile, "utf-8");
+		const lines = content.trim().split("\n");
+		expect(lines).toHaveLength(1);
+	});
+
+	test("複数のイベントを記録できる", async () => {
+		const recorder = new SessionRecorder(testFile);
+		await recorder.startRecording();
+
+		await recorder.recordIteration(1, "reviewer", "prompt", "output", [
+			"review.approved",
+			"LOOP_COMPLETE",
+		]);
+
+		await recorder.stopRecording();
+
+		const content = await readFile(testFile, "utf-8");
+		const record = JSON.parse(content.trim());
+
+		expect(record.events).toEqual(["review.approved", "LOOP_COMPLETE"]);
+	});
+});

--- a/src/core/session-recorder.ts
+++ b/src/core/session-recorder.ts
@@ -1,0 +1,93 @@
+import { appendFile, mkdir, stat, unlink, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { logger } from "./logger.js";
+
+export interface SessionRecord {
+	iteration: number;
+	hat: string;
+	prompt: string;
+	output: string;
+	events: string[];
+	timestamp: string;
+}
+
+export class SessionRecorder {
+	private readonly filePath: string;
+	private readonly maxSizeBytes = 100 * 1024 * 1024;
+	private isRecording = false;
+
+	constructor(filePath: string) {
+		this.filePath = filePath;
+	}
+
+	async startRecording(): Promise<void> {
+		try {
+			await mkdir(dirname(this.filePath), { recursive: true });
+			await unlink(this.filePath).catch(() => {});
+			await writeFile(this.filePath, "");
+
+			this.isRecording = true;
+			logger.info(`セッション記録開始: ${this.filePath}`);
+		} catch (error) {
+			logger.error(`セッション記録の開始に失敗しました: ${error}`);
+			throw error;
+		}
+	}
+
+	async recordIteration(
+		iteration: number,
+		hat: string,
+		prompt: string,
+		output: string,
+		events: string[],
+	): Promise<void> {
+		if (!this.isRecording) {
+			logger.warn("セッション記録が開始されていません");
+			return;
+		}
+
+		try {
+			const sizeExceeded = await this.checkSize();
+			if (sizeExceeded) {
+				return;
+			}
+
+			const record: SessionRecord = {
+				iteration,
+				hat,
+				prompt,
+				output,
+				events,
+				timestamp: new Date().toISOString(),
+			};
+
+			const line = `${JSON.stringify(record)}\n`;
+			await appendFile(this.filePath, line);
+
+			logger.debug(`イテレーション ${iteration} を記録`);
+		} catch (error) {
+			logger.error(
+				`セッション記録の書き込みに失敗しました。記録をスキップして実行継続します。: ${error}`,
+			);
+		}
+	}
+
+	async stopRecording(): Promise<void> {
+		this.isRecording = false;
+		logger.info(`セッション記録完了: ${this.filePath}`);
+	}
+
+	private async checkSize(): Promise<boolean> {
+		try {
+			const stats = await stat(this.filePath);
+			if (stats.size > this.maxSizeBytes) {
+				logger.warn("セッション記録のサイズが上限（100MB）を超えました。記録を停止します。");
+				this.isRecording = false;
+				return true;
+			}
+		} catch {
+			// ファイルが存在しない場合は無視
+		}
+		return false;
+	}
+}

--- a/src/core/session-replayer.test.ts
+++ b/src/core/session-replayer.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { rm } from "node:fs/promises";
+import { SessionRecorder } from "./session-recorder.js";
+import { SessionReplayer } from "./session-replayer.js";
+
+const testDir = ".test-session-replayer";
+const testFile = `${testDir}/session.jsonl`;
+
+beforeEach(async () => {
+	await rm(testDir, { recursive: true, force: true });
+});
+
+afterEach(async () => {
+	await rm(testDir, { recursive: true, force: true });
+});
+
+describe("SessionReplayer", () => {
+	test("記録されたセッションをリプレイできる", async () => {
+		const recorder = new SessionRecorder(testFile);
+		await recorder.startRecording();
+		await recorder.recordIteration(1, "planner", "prompt1", "output1", ["plan.ready"]);
+		await recorder.recordIteration(2, "implementer", "prompt2", "output2", ["code.written"]);
+		await recorder.stopRecording();
+
+		const replayer = new SessionReplayer(testFile);
+		const result = await replayer.replay();
+
+		expect(result.success).toBe(true);
+		expect(result.iterations).toBe(2);
+		expect(result.errors).toHaveLength(0);
+	});
+
+	test("ファイルが存在しない場合はエラーを返す", async () => {
+		const replayer = new SessionReplayer("non-existent.jsonl");
+		const result = await replayer.replay();
+
+		expect(result.success).toBe(false);
+		expect(result.iterations).toBe(0);
+		expect(result.errors).toHaveLength(1);
+		expect(result.errors[0]).toContain("セッション記録ファイルが見つかりません");
+	});
+
+	test("loadRecordsでレコード配列を取得できる", async () => {
+		const recorder = new SessionRecorder(testFile);
+		await recorder.startRecording();
+		await recorder.recordIteration(1, "planner", "prompt1", "output1", ["plan.ready"]);
+		await recorder.recordIteration(2, "implementer", "prompt2", "output2", []);
+		await recorder.stopRecording();
+
+		const replayer = new SessionReplayer(testFile);
+		const records = await replayer.loadRecords();
+
+		expect(records).toHaveLength(2);
+		expect(records[0].iteration).toBe(1);
+		expect(records[0].hat).toBe("planner");
+		expect(records[1].iteration).toBe(2);
+		expect(records[1].hat).toBe("implementer");
+	});
+
+	test("空のセッションファイルをリプレイできる", async () => {
+		const recorder = new SessionRecorder(testFile);
+		await recorder.startRecording();
+		await recorder.stopRecording();
+
+		const replayer = new SessionReplayer(testFile);
+		const result = await replayer.replay();
+
+		expect(result.success).toBe(true);
+		expect(result.iterations).toBe(0);
+	});
+
+	test("複数のイベントを持つレコードをリプレイできる", async () => {
+		const recorder = new SessionRecorder(testFile);
+		await recorder.startRecording();
+		await recorder.recordIteration(1, "reviewer", "prompt", "output", [
+			"review.approved",
+			"LOOP_COMPLETE",
+		]);
+		await recorder.stopRecording();
+
+		const replayer = new SessionReplayer(testFile);
+		const result = await replayer.replay();
+
+		expect(result.success).toBe(true);
+		expect(result.iterations).toBe(1);
+	});
+});

--- a/src/core/session-replayer.ts
+++ b/src/core/session-replayer.ts
@@ -1,0 +1,81 @@
+import { readFile } from "node:fs/promises";
+import { logger } from "./logger.js";
+import type { SessionRecord } from "./session-recorder.js";
+
+export interface ReplayResult {
+	success: boolean;
+	iterations: number;
+	errors: string[];
+}
+
+export class SessionReplayer {
+	private readonly filePath: string;
+
+	constructor(filePath: string) {
+		this.filePath = filePath;
+	}
+
+	async replay(): Promise<ReplayResult> {
+		const errors: string[] = [];
+
+		try {
+			const records = await this.loadRecords();
+			logger.info(`セッションリプレイ開始: ${records.length}イテレーション`);
+
+			for (const record of records) {
+				try {
+					await this.replayIteration(record);
+				} catch (error) {
+					const errorMsg = `イテレーション ${record.iteration} のリプレイに失敗: ${error}`;
+					logger.error(errorMsg);
+					errors.push(errorMsg);
+				}
+			}
+
+			const success = errors.length === 0;
+			logger.info(`セッションリプレイ完了: ${success ? "成功" : "失敗"}`);
+
+			return {
+				success,
+				iterations: records.length,
+				errors,
+			};
+		} catch (error) {
+			logger.error(`セッションリプレイに失敗: ${error}`);
+			return {
+				success: false,
+				iterations: 0,
+				errors: [String(error)],
+			};
+		}
+	}
+
+	async loadRecords(): Promise<SessionRecord[]> {
+		try {
+			const content = await readFile(this.filePath, "utf-8");
+			const lines = content
+				.trim()
+				.split("\n")
+				.filter((line) => line);
+
+			return lines.map((line) => JSON.parse(line) as SessionRecord);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+				throw new Error(`セッション記録ファイルが見つかりません: ${this.filePath}`);
+			}
+			throw error;
+		}
+	}
+
+	private async replayIteration(record: SessionRecord): Promise<void> {
+		logger.info(`Replaying iteration ${record.iteration}: ${record.hat}`);
+
+		const outputPreview =
+			record.output.length > 200 ? `${record.output.substring(0, 200)}...` : record.output;
+		logger.info(`Output: ${outputPreview}`);
+
+		if (record.events.length > 0) {
+			logger.info(`Events: ${record.events.join(", ")}`);
+		}
+	}
+}


### PR DESCRIPTION
## Summary

セッションをJSONL形式で記録し、デバッグやテストに活用できる Session Recording 機能を実装しました。

## Changes

- **SessionRecorder クラス** (`src/core/session-recorder.ts`)
  - JSONL 形式でイテレーションを記録
  - 100MB サイズ上限チェック
  - 追記型ログによる安全な記録

- **SessionReplayer クラス** (`src/core/session-replayer.ts`)
  - 記録されたセッションを読み込み・リプレイ
  - API コールなしで出力を再現
  - Smoke test 用フィクスチャとして活用可能

- **CLI 統合** (`src/cli.ts`)
  - `--record-session <file>`: セッション記録オプション
  - `orch replay <file>`: セッションリプレイコマンド

- **Loop Engine 統合** (`src/core/loop.ts`)
  - Simple Loop / Hat Loop 両方で記録をサポート
  - イテレーション毎に Hat 名、プロンプト、出力、イベントを記録

- **単体テスト** (`src/core/session-recorder.test.ts`, `src/core/session-replayer.test.ts`)
  - 10件のテストケース（全通過）

## Testing

```bash
bun test src/core/session-recorder.test.ts src/core/session-replayer.test.ts  # 10 pass
bun test                                                                        # 491 pass
bun run typecheck                                                               # OK
```

## CLI Demo

```bash
# セッション記録
orch run --issue 42 --auto --record-session session.jsonl

# セッションリプレイ
orch replay session.jsonl
```

## JSONL Format

```jsonl
{"iteration":1,"hat":"planner","prompt":"...","output":"...","events":["plan.ready"],"timestamp":"2026-01-27T00:00:00Z"}
{"iteration":2,"hat":"implementer","prompt":"...","output":"...","events":["code.written"],"timestamp":"2026-01-27T00:05:00Z"}
```

Closes #64