### PR TITLE
feat: [F-202] HybridEnvironmentBuilder (Worktree + Container-Use Integration)

### DIFF
--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -564,3 +564,41 @@ export class GlobPatternError extends SandboxError {
 		this.name = "GlobPatternError";
 	}
 }
+
+// v2.0.0 新規エラークラス
+
+/**
+ * ハイブリッド環境エラー
+ *
+ * Worktree + Container-Use統合（F-202）で発生するエラーを表現します。
+ *
+ * @example
+ * ```typescript
+ * // worktree作成失敗
+ * throw new HybridEnvironmentError(
+ *   "worktree作成失敗: .worktrees/issue-42",
+ *   { issueNumber: 42, cause: "branch already exists" }
+ * );
+ *
+ * // container-use環境作成失敗
+ * throw new HybridEnvironmentError(
+ *   "container-use環境作成失敗",
+ *   { issueNumber: 42, worktreePath: ".worktrees/issue-42", stderr: "connection refused" }
+ * );
+ *
+ * // 環境削除失敗
+ * throw new HybridEnvironmentError(
+ *   "環境削除失敗",
+ *   { issueNumber: 42, environmentId: "env-123" }
+ * );
+ * ```
+ */
+export class HybridEnvironmentError extends SandboxError {
+	constructor(message: string, details?: Record<string, unknown>) {
+		super(message, {
+			code: "HYBRID_ENVIRONMENT_ERROR",
+			details,
+		});
+		this.name = "HybridEnvironmentError";
+	}
+}

--- a/src/worktree/hybrid-environment-builder.test.ts
+++ b/src/worktree/hybrid-environment-builder.test.ts
@@ -1,0 +1,307 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { HybridEnvironmentError } from "../core/errors";
+import type { WorktreeConfig } from "../core/types";
+import {
+	HybridEnvironmentBuilder,
+	type HybridEnvironmentBuilderConfig,
+} from "./hybrid-environment-builder";
+import { WorktreeManager } from "./worktree-manager";
+
+interface ProcessResult {
+	stdout: string;
+	stderr: string;
+	exitCode: number;
+}
+
+interface MockProcessExecutor {
+	execute: (command: string, args: string[]) => Promise<ProcessResult>;
+}
+
+describe("HybridEnvironmentBuilder", () => {
+	let tempDir: string;
+	let mockExecutor: MockProcessExecutor;
+	let defaultWorktreeConfig: WorktreeConfig;
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join("/tmp", "hybrid-env-test-"));
+
+		defaultWorktreeConfig = {
+			enabled: true,
+			base_dir: ".worktrees",
+			auto_cleanup: true,
+			copy_env_files: [".env"],
+		};
+
+		mockExecutor = {
+			execute: mock(async (_command: string, _args: string[]): Promise<ProcessResult> => {
+				return { stdout: "", stderr: "", exitCode: 0 };
+			}),
+		};
+	});
+
+	afterEach(() => {
+		if (fs.existsSync(tempDir)) {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	describe("buildEnvironment", () => {
+		it("パターンA: ハイブリッド環境（worktree + container-use）を構築できる", async () => {
+			const config: HybridEnvironmentBuilderConfig = {
+				worktree: defaultWorktreeConfig,
+				sandbox: { type: "container-use" },
+			};
+
+			const cuExecutor: MockProcessExecutor = {
+				execute: mock(async (command: string, args: string[]): Promise<ProcessResult> => {
+					if (command === "cu" && args.includes("env") && args.includes("create")) {
+						return { stdout: "env-abc-123", stderr: "", exitCode: 0 };
+					}
+					return { stdout: "", stderr: "", exitCode: 0 };
+				}),
+			};
+
+			const worktreeManager = new WorktreeManager(defaultWorktreeConfig, tempDir, mockExecutor);
+			const builder = new HybridEnvironmentBuilder(config, worktreeManager, tempDir, cuExecutor);
+
+			const result = await builder.buildEnvironment(42);
+
+			expect(result.type).toBe("hybrid");
+			expect(result.issueNumber).toBe(42);
+			expect(result.environmentType).toBe("container-use");
+			expect(result.environmentId).toBe("env-abc-123");
+			expect(result.worktree).toBeDefined();
+			expect(result.worktree?.issueNumber).toBe(42);
+			expect(result.workingDirectory).toContain(".worktrees/issue-42");
+		});
+
+		it("パターンB: ハイブリッド環境（worktree + docker）を構築できる", async () => {
+			const config: HybridEnvironmentBuilderConfig = {
+				worktree: defaultWorktreeConfig,
+				sandbox: {
+					type: "docker",
+					docker: { image: "node:20-alpine", network: "none", timeout: 300 },
+				},
+			};
+
+			const dockerExecutor: MockProcessExecutor = {
+				execute: mock(async (command: string, args: string[]): Promise<ProcessResult> => {
+					if (command === "docker" && args.includes("run")) {
+						return { stdout: "container-xyz-789", stderr: "", exitCode: 0 };
+					}
+					return { stdout: "", stderr: "", exitCode: 0 };
+				}),
+			};
+
+			const worktreeManager = new WorktreeManager(defaultWorktreeConfig, tempDir, mockExecutor);
+			const builder = new HybridEnvironmentBuilder(
+				config,
+				worktreeManager,
+				tempDir,
+				dockerExecutor,
+			);
+
+			const result = await builder.buildEnvironment(43);
+
+			expect(result.type).toBe("hybrid");
+			expect(result.issueNumber).toBe(43);
+			expect(result.environmentType).toBe("docker");
+			expect(result.environmentId).toBe("container-xyz-789");
+			expect(result.worktree).toBeDefined();
+		});
+
+		it("パターンC: worktreeのみ構築（ホスト実行）", async () => {
+			const config: HybridEnvironmentBuilderConfig = {
+				worktree: defaultWorktreeConfig,
+				sandbox: { type: "host" },
+			};
+
+			const worktreeManager = new WorktreeManager(defaultWorktreeConfig, tempDir, mockExecutor);
+			const builder = new HybridEnvironmentBuilder(config, worktreeManager, tempDir, mockExecutor);
+
+			const result = await builder.buildEnvironment(44);
+
+			expect(result.type).toBe("worktree-only");
+			expect(result.issueNumber).toBe(44);
+			expect(result.environmentType).toBe("host");
+			expect(result.environmentId).toBeUndefined();
+			expect(result.worktree).toBeDefined();
+			expect(result.workingDirectory).toContain(".worktrees/issue-44");
+		});
+
+		it("パターンD: container-useのみ構築（worktree無効）", async () => {
+			const config: HybridEnvironmentBuilderConfig = {
+				worktree: { ...defaultWorktreeConfig, enabled: false },
+				sandbox: { type: "container-use" },
+			};
+
+			const cuExecutor: MockProcessExecutor = {
+				execute: mock(async (command: string, args: string[]): Promise<ProcessResult> => {
+					if (command === "cu" && args.includes("env") && args.includes("create")) {
+						return { stdout: "env-only-456", stderr: "", exitCode: 0 };
+					}
+					return { stdout: "", stderr: "", exitCode: 0 };
+				}),
+			};
+
+			const worktreeManager = new WorktreeManager(
+				{ ...defaultWorktreeConfig, enabled: false },
+				tempDir,
+				mockExecutor,
+			);
+			const builder = new HybridEnvironmentBuilder(config, worktreeManager, tempDir, cuExecutor);
+
+			const result = await builder.buildEnvironment(45);
+
+			expect(result.type).toBe("container-only");
+			expect(result.issueNumber).toBe(45);
+			expect(result.environmentType).toBe("container-use");
+			expect(result.environmentId).toBe("env-only-456");
+			expect(result.worktree).toBeUndefined();
+			expect(result.workingDirectory).toBe(tempDir);
+		});
+
+		it("パターンF: ホスト環境構築（worktree無効 & host）", async () => {
+			const config: HybridEnvironmentBuilderConfig = {
+				worktree: { ...defaultWorktreeConfig, enabled: false },
+				sandbox: { type: "host" },
+			};
+
+			const worktreeManager = new WorktreeManager(
+				{ ...defaultWorktreeConfig, enabled: false },
+				tempDir,
+				mockExecutor,
+			);
+			const builder = new HybridEnvironmentBuilder(config, worktreeManager, tempDir, mockExecutor);
+
+			const result = await builder.buildEnvironment(46);
+
+			expect(result.type).toBe("host");
+			expect(result.issueNumber).toBe(46);
+			expect(result.environmentType).toBe("host");
+			expect(result.environmentId).toBeUndefined();
+			expect(result.worktree).toBeUndefined();
+			expect(result.workingDirectory).toBe(tempDir);
+		});
+
+		it("container-use作成失敗時にエラーをスローする", async () => {
+			const config: HybridEnvironmentBuilderConfig = {
+				worktree: defaultWorktreeConfig,
+				sandbox: { type: "container-use" },
+			};
+
+			const failingExecutor: MockProcessExecutor = {
+				execute: mock(async (command: string, _args: string[]): Promise<ProcessResult> => {
+					if (command === "cu") {
+						return { stdout: "", stderr: "connection refused", exitCode: 1 };
+					}
+					return { stdout: "", stderr: "", exitCode: 0 };
+				}),
+			};
+
+			const worktreeManager = new WorktreeManager(defaultWorktreeConfig, tempDir, mockExecutor);
+			const builder = new HybridEnvironmentBuilder(
+				config,
+				worktreeManager,
+				tempDir,
+				failingExecutor,
+			);
+
+			await expect(builder.buildEnvironment(47)).rejects.toThrow(HybridEnvironmentError);
+			await expect(builder.buildEnvironment(47)).rejects.toThrow(/container-use環境作成失敗/);
+		});
+
+		it("docker起動失敗時にエラーをスローする", async () => {
+			const config: HybridEnvironmentBuilderConfig = {
+				worktree: defaultWorktreeConfig,
+				sandbox: {
+					type: "docker",
+					docker: { image: "node:20-alpine", network: "none", timeout: 300 },
+				},
+			};
+
+			const failingExecutor: MockProcessExecutor = {
+				execute: mock(async (command: string, _args: string[]): Promise<ProcessResult> => {
+					if (command === "docker") {
+						return { stdout: "", stderr: "image not found", exitCode: 1 };
+					}
+					return { stdout: "", stderr: "", exitCode: 0 };
+				}),
+			};
+
+			const worktreeManager = new WorktreeManager(defaultWorktreeConfig, tempDir, mockExecutor);
+			const builder = new HybridEnvironmentBuilder(
+				config,
+				worktreeManager,
+				tempDir,
+				failingExecutor,
+			);
+
+			await expect(builder.buildEnvironment(48)).rejects.toThrow(HybridEnvironmentError);
+			await expect(builder.buildEnvironment(48)).rejects.toThrow(/Docker環境作成失敗/);
+		});
+	});
+
+	describe("destroyEnvironment", () => {
+		it("ハイブリッド環境（worktree + container-use）を削除できる", async () => {
+			const config: HybridEnvironmentBuilderConfig = {
+				worktree: defaultWorktreeConfig,
+				sandbox: { type: "container-use" },
+			};
+
+			const cuExecutor: MockProcessExecutor = {
+				execute: mock(async (command: string, args: string[]): Promise<ProcessResult> => {
+					if (command === "cu" && args.includes("env") && args.includes("create")) {
+						return { stdout: "env-to-delete", stderr: "", exitCode: 0 };
+					}
+					return { stdout: "", stderr: "", exitCode: 0 };
+				}),
+			};
+
+			const worktreeManager = new WorktreeManager(defaultWorktreeConfig, tempDir, mockExecutor);
+			const builder = new HybridEnvironmentBuilder(config, worktreeManager, tempDir, cuExecutor);
+
+			await builder.buildEnvironment(49);
+			await builder.destroyEnvironment(49);
+
+			const worktree = await worktreeManager.getWorktree(49);
+			expect(worktree).toBeNull();
+		});
+
+		it("存在しない環境の削除は何もしない", async () => {
+			const config: HybridEnvironmentBuilderConfig = {
+				worktree: defaultWorktreeConfig,
+				sandbox: { type: "host" },
+			};
+
+			const worktreeManager = new WorktreeManager(defaultWorktreeConfig, tempDir, mockExecutor);
+			const builder = new HybridEnvironmentBuilder(config, worktreeManager, tempDir, mockExecutor);
+
+			await expect(builder.destroyEnvironment(999)).resolves.toBeUndefined();
+		});
+	});
+
+	describe("並列環境構築", () => {
+		it("複数ハイブリッド環境を並列に構築できる", async () => {
+			const config: HybridEnvironmentBuilderConfig = {
+				worktree: defaultWorktreeConfig,
+				sandbox: { type: "host" },
+			};
+
+			const worktreeManager = new WorktreeManager(defaultWorktreeConfig, tempDir, mockExecutor);
+			const builder = new HybridEnvironmentBuilder(config, worktreeManager, tempDir, mockExecutor);
+
+			const results = await Promise.all([
+				builder.buildEnvironment(51),
+				builder.buildEnvironment(52),
+				builder.buildEnvironment(53),
+			]);
+
+			expect(results).toHaveLength(3);
+			expect(results.map((r) => r.issueNumber).sort()).toEqual([51, 52, 53]);
+			expect(results.every((r) => r.type === "worktree-only")).toBe(true);
+		});
+	});
+});

--- a/src/worktree/hybrid-environment-builder.ts
+++ b/src/worktree/hybrid-environment-builder.ts
@@ -1,0 +1,188 @@
+import * as path from "node:path";
+import { HybridEnvironmentError } from "../core/errors";
+import type { SandboxConfig, WorktreeConfig, WorktreeInfo } from "../core/types";
+import type { ProcessExecutor } from "./worktree-manager";
+import { BunProcessExecutor, type WorktreeManager } from "./worktree-manager";
+
+export interface HybridEnvironmentBuilderConfig {
+	worktree: WorktreeConfig;
+	sandbox: SandboxConfig;
+	container?: {
+		enabled?: boolean;
+		image?: string;
+		env_id?: string;
+	};
+}
+
+export type EnvironmentType = "hybrid" | "worktree-only" | "container-only" | "host";
+
+export interface EnvironmentInfo {
+	issueNumber: number;
+	type: EnvironmentType;
+	worktree?: WorktreeInfo;
+	environmentType: "container-use" | "docker" | "host";
+	environmentId?: string;
+	workingDirectory: string;
+}
+
+export class HybridEnvironmentBuilder {
+	private readonly config: HybridEnvironmentBuilderConfig;
+	private readonly worktreeManager: WorktreeManager;
+	private readonly projectRoot: string;
+	private readonly executor: ProcessExecutor;
+	private readonly environmentStore: Map<number, EnvironmentInfo> = new Map();
+
+	constructor(
+		config: HybridEnvironmentBuilderConfig,
+		worktreeManager: WorktreeManager,
+		projectRoot: string,
+		executor?: ProcessExecutor,
+	) {
+		this.config = config;
+		this.worktreeManager = worktreeManager;
+		this.projectRoot = projectRoot;
+		this.executor = executor ?? new BunProcessExecutor();
+	}
+
+	async buildEnvironment(issueNumber: number): Promise<EnvironmentInfo> {
+		const worktreeEnabled = this.config.worktree.enabled;
+		const sandboxType = this.config.sandbox.type;
+
+		let worktree: WorktreeInfo | undefined;
+		let environmentId: string | undefined;
+		let environmentType: "container-use" | "docker" | "host";
+		let type: EnvironmentType;
+		let workingDirectory: string;
+
+		if (worktreeEnabled) {
+			const worktreeResult = await this.worktreeManager.createWorktree(
+				issueNumber,
+				sandboxType === "container-use"
+					? "container-use"
+					: sandboxType === "docker"
+						? "docker"
+						: "host",
+			);
+			if (worktreeResult) {
+				worktree = worktreeResult;
+				workingDirectory = path.join(this.projectRoot, worktreeResult.path);
+			} else {
+				workingDirectory = this.projectRoot;
+			}
+
+			if (sandboxType === "container-use") {
+				environmentId = await this.createContainerUseEnvironment(workingDirectory);
+				await this.worktreeManager.updateWorktree(issueNumber, { environmentId });
+				environmentType = "container-use";
+				type = "hybrid";
+			} else if (sandboxType === "docker") {
+				environmentId = await this.createDockerEnvironment(workingDirectory);
+				await this.worktreeManager.updateWorktree(issueNumber, { environmentId });
+				environmentType = "docker";
+				type = "hybrid";
+			} else {
+				environmentType = "host";
+				type = "worktree-only";
+			}
+		} else {
+			workingDirectory = this.projectRoot;
+
+			if (sandboxType === "container-use") {
+				environmentId = await this.createContainerUseEnvironment(workingDirectory);
+				environmentType = "container-use";
+				type = "container-only";
+			} else if (sandboxType === "docker") {
+				environmentId = await this.createDockerEnvironment(workingDirectory);
+				environmentType = "docker";
+				type = "container-only";
+			} else {
+				environmentType = "host";
+				type = "host";
+			}
+		}
+
+		const info: EnvironmentInfo = {
+			issueNumber,
+			type,
+			worktree,
+			environmentType,
+			environmentId,
+			workingDirectory,
+		};
+
+		this.environmentStore.set(issueNumber, info);
+		return info;
+	}
+
+	async destroyEnvironment(issueNumber: number): Promise<void> {
+		const info = this.environmentStore.get(issueNumber);
+
+		if (info?.environmentId) {
+			if (info.environmentType === "container-use") {
+				await this.deleteContainerUseEnvironment(info.environmentId);
+			} else if (info.environmentType === "docker") {
+				await this.deleteDockerContainer(info.environmentId);
+			}
+		}
+
+		if (info?.worktree) {
+			await this.worktreeManager.removeWorktree(issueNumber);
+		}
+
+		this.environmentStore.delete(issueNumber);
+	}
+
+	private async createContainerUseEnvironment(sourcePath: string): Promise<string> {
+		const result = await this.executor.execute("cu", ["env", "create", "--source", sourcePath]);
+
+		if (result.exitCode !== 0) {
+			throw new HybridEnvironmentError(`container-use環境作成失敗: ${result.stderr}`, {
+				sourcePath,
+				stderr: result.stderr,
+				exitCode: result.exitCode,
+			});
+		}
+
+		return result.stdout.trim();
+	}
+
+	private async createDockerEnvironment(workspacePath: string): Promise<string> {
+		const dockerConfig = this.config.sandbox.docker;
+		const image = dockerConfig?.image ?? "node:20-alpine";
+		const network = dockerConfig?.network ?? "bridge";
+
+		const result = await this.executor.execute("docker", [
+			"run",
+			"-d",
+			"--network",
+			network,
+			"-v",
+			`${workspacePath}:/workspace`,
+			"-w",
+			"/workspace",
+			image,
+			"tail",
+			"-f",
+			"/dev/null",
+		]);
+
+		if (result.exitCode !== 0) {
+			throw new HybridEnvironmentError(`Docker環境作成失敗: ${result.stderr}`, {
+				workspacePath,
+				image,
+				stderr: result.stderr,
+				exitCode: result.exitCode,
+			});
+		}
+
+		return result.stdout.trim();
+	}
+
+	private async deleteContainerUseEnvironment(environmentId: string): Promise<void> {
+		await this.executor.execute("cu", ["env", "delete", environmentId]);
+	}
+
+	private async deleteDockerContainer(containerId: string): Promise<void> {
+		await this.executor.execute("docker", ["rm", "-f", containerId]);
+	}
+}


### PR DESCRIPTION
## 概要
worktree（ファイルシステム分離）とcontainer-use（環境分離）を組み合わせたハイブリッド環境を自動構築するHybridEnvironmentBuilderクラスを追加します（v2.0.0 並列実行環境の基盤）。

## 変更内容
- `src/core/errors.ts` - HybridEnvironmentError追加（+38行）
- `src/worktree/hybrid-environment-builder.ts` - HybridEnvironmentBuilderクラス実装（+175行）
- `src/worktree/hybrid-environment-builder.test.ts` - 10テスト追加（+305行）

## 機能

### 環境組み合わせパターン

| パターン | worktree | sandbox | type |
|---------|----------|---------|------|
| **A: ハイブリッド** | ✅ enabled | container-use | hybrid |
| **B: worktree + Docker** | ✅ enabled | docker | hybrid |
| **C: worktreeのみ** | ✅ enabled | host | worktree-only |
| **D: container-useのみ** | ❌ disabled | container-use | container-only |
| **E: Dockerのみ** | ❌ disabled | docker | container-only |
| **F: ホスト実行** | ❌ disabled | host | host |

### 主要メソッド
- `buildEnvironment(issueNumber)` - 環境を構築しEnvironmentInfoを返す
- `destroyEnvironment(issueNumber)` - 環境を削除

## テスト
- 10テスト追加（全て通過）
- 全体695テスト通過

## 依存関係
- F-201: WorktreeManager（#80で実装済み）

## 関連設計書
`docs/designs/detailed/v2.0.0機能/phase2-並列実行環境/Worktree-ContainerUse統合/詳細設計書.md`

Closes #81