### PR TITLE
fix: propagate workdir from hybrid environment to backend execution

### DIFF
--- a/src/adapters/claude.ts
+++ b/src/adapters/claude.ts
@@ -9,15 +9,21 @@ export interface ClaudeBackendConfig {
 	 * 設定すると、stdout/stderrをリアルタイムでログファイルに書き込む
 	 */
 	outputStreamer?: BackendOutputStreamer;
+	/**
+	 * ワーキングディレクトリ
+	 */
+	workdir?: string;
 }
 
 export class ClaudeBackend extends BaseBackend {
 	readonly name = "claude";
 	private readonly outputStreamer?: BackendOutputStreamer;
+	private readonly workdir?: string;
 
 	constructor(config: ClaudeBackendConfig = {}) {
 		super();
 		this.outputStreamer = config.outputStreamer;
+		this.workdir = config.workdir;
 	}
 
 	async execute(prompt: string): Promise<BackendResult> {
@@ -25,7 +31,7 @@ export class ClaudeBackend extends BaseBackend {
 			const { stdout, exitCode } = await exec(
 				"claude",
 				["-p", prompt, "--allowedTools", "Edit,Write,Bash,Read,Glob,Grep"],
-				{ reject: false, outputStreamer: this.outputStreamer },
+				{ reject: false, outputStreamer: this.outputStreamer, cwd: this.workdir },
 			);
 
 			return {

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -7,14 +7,15 @@ export type BackendType = "claude" | "opencode" | "gemini" | "container";
 
 export interface CreateBackendOptions {
 	container?: ContainerConfig;
+	workdir?: string;
 }
 
 export function createBackend(type: BackendType, options: CreateBackendOptions = {}): Backend {
 	switch (type) {
 		case "claude":
-			return new ClaudeBackend();
+			return new ClaudeBackend({ workdir: options.workdir });
 		case "opencode":
-			return new OpenCodeBackend();
+			return new OpenCodeBackend({ workdir: options.workdir });
 		case "container":
 			return new ContainerBackend(options.container);
 		case "gemini":

--- a/src/adapters/opencode.ts
+++ b/src/adapters/opencode.ts
@@ -9,15 +9,21 @@ export interface OpenCodeBackendConfig {
 	 * 設定すると、stdout/stderrをリアルタイムでログファイルに書き込む
 	 */
 	outputStreamer?: BackendOutputStreamer;
+	/**
+	 * ワーキングディレクトリ
+	 */
+	workdir?: string;
 }
 
 export class OpenCodeBackend extends BaseBackend {
 	readonly name = "opencode";
 	private readonly outputStreamer?: BackendOutputStreamer;
+	private readonly workdir?: string;
 
 	constructor(config: OpenCodeBackendConfig = {}) {
 		super();
 		this.outputStreamer = config.outputStreamer;
+		this.workdir = config.workdir;
 	}
 
 	async execute(prompt: string): Promise<BackendResult> {
@@ -25,6 +31,7 @@ export class OpenCodeBackend extends BaseBackend {
 			const { stdout, exitCode } = await exec("opencode", ["run", prompt], {
 				reject: false,
 				outputStreamer: this.outputStreamer,
+				cwd: this.workdir,
 			});
 
 			return {

--- a/src/core/exec.ts
+++ b/src/core/exec.ts
@@ -12,6 +12,11 @@ export interface ExecOptions {
 	 * 設定すると、stdout/stderrをリアルタイムでログファイルに書き込む
 	 */
 	outputStreamer?: BackendOutputStreamer;
+	/**
+	 * ワーキングディレクトリ
+	 * 指定するとこのディレクトリでコマンドを実行する
+	 */
+	cwd?: string;
 }
 
 export async function exec(
@@ -19,11 +24,12 @@ export async function exec(
 	args: string[],
 	options: ExecOptions = {},
 ): Promise<ExecResult> {
-	const { reject = true, outputStreamer } = options;
+	const { reject = true, outputStreamer, cwd } = options;
 
 	const proc = Bun.spawn([cmd, ...args], {
 		stdout: "pipe",
 		stderr: "pipe",
+		cwd,
 	});
 
 	// ストリーミングが有効な場合、リアルタイムでログに書き込む

--- a/src/core/loop.ts
+++ b/src/core/loop.ts
@@ -108,7 +108,11 @@ export async function runLoop(options: LoopOptions): Promise<void> {
 	}
 
 	const context = buildLoopContext(issue, loopConfig, options);
-	const backend = createLoopBackend(config, loopConfig.containerEnabled);
+	const backend = createLoopBackend(
+		config,
+		loopConfig.containerEnabled,
+		environmentInfo?.workingDirectory,
+	);
 	const collector = loopConfig.shouldGenerateReport ? createReportCollector() : null;
 
 	const logWriter = new LogWriter({
@@ -222,7 +226,7 @@ function buildLoopContext(issue: Issue, config: LoopConfig, options: LoopOptions
 	};
 }
 
-function createLoopBackend(config: Config, containerEnabled: boolean): Backend {
+function createLoopBackend(config: Config, containerEnabled: boolean, workdir?: string): Backend {
 	const backendType = containerEnabled
 		? "container"
 		: (config.backend.type as "claude" | "opencode");
@@ -230,6 +234,7 @@ function createLoopBackend(config: Config, containerEnabled: boolean): Backend {
 		container: config.container
 			? { image: config.container.image, envId: config.container.env_id }
 			: undefined,
+		workdir,
 	});
 }
 


### PR DESCRIPTION
## Summary

- `exec.ts`に`cwd`オプションを追加し、コマンド実行時のワーキングディレクトリを指定可能に
- `ClaudeBackend`と`OpenCodeBackend`に`workdir`オプションを追加
- `createBackend()`で`workdir`オプションをバックエンドに渡すように更新
- `loop.ts`で`environmentInfo.workingDirectory`を`createLoopBackend`に伝播

## Problem

Issue #106 で `HybridEnvironmentBuilder` が導入されたが、作成された環境の `workingDirectory` がバックエンド実行時に使用されていなかった。そのため、worktree や container-use 環境を作成しても、バックエンド (claude/opencode) は常に `process.cwd()` で実行されていた。

## Solution

1. `exec.ts`: `ExecOptions.cwd` を追加し、`Bun.spawn()` に渡す
2. `ClaudeBackend` / `OpenCodeBackend`: `workdir` オプションを受け取り、`exec()` に `cwd` として渡す
3. `createBackend()`: `workdir` オプションを追加し、各バックエンドに渡す
4. `loop.ts`: `buildHybridEnvironment()` の戻り値 `environmentInfo?.workingDirectory` を `createLoopBackend()` に渡す

## Testing

- 型チェック: Pass
- 全テスト (736件): Pass

Closes #108