### PR TITLE
fix: skip hybrid environment build when sandbox is undefined or host

### DIFF
--- a/src/core/loop.ts
+++ b/src/core/loop.ts
@@ -1028,7 +1028,10 @@ async function buildHybridEnvironment(
 	const worktreeConfig = options.worktreeConfig ?? options.config.worktree;
 	const sandboxConfig = options.sandboxConfig ?? options.config.sandbox;
 
-	if (!worktreeConfig?.enabled && sandboxConfig?.type === "host") {
+	const worktreeDisabled = !worktreeConfig?.enabled;
+	const sandboxIsHost = !sandboxConfig || sandboxConfig.type === "host";
+
+	if (worktreeDisabled && sandboxIsHost) {
 		return null;
 	}
 


### PR DESCRIPTION
## Problem

`buildHybridEnvironment()` の早期リターン条件が不正確で、`sandboxConfig` が未定義の場合に誤って `HybridEnvironmentBuilder` が呼び出されていた。

```typescript
// Before: sandboxConfig が undefined の場合、undefined === "host" は false
if (!worktreeConfig?.enabled && sandboxConfig?.type === "host") {
    return null;
}
```

## Solution

条件を明確化：
```typescript
const worktreeDisabled = !worktreeConfig?.enabled;
const sandboxIsHost = !sandboxConfig || sandboxConfig.type === "host";

if (worktreeDisabled && sandboxIsHost) {
    return null;
}
```

worktree が無効かつ sandbox が未定義または host の場合は、環境構築をスキップする。

## Testing

- 型チェック: Pass
- 全テスト (736件): Pass