### PR TITLE
fix: correct opencode adapter arguments

### DIFF
--- a/src/adapters/opencode.ts
+++ b/src/adapters/opencode.ts
@@ -6,7 +6,7 @@ export class OpenCodeAdapter implements IBackendAdapter {
 	}
 
 	getArgs(promptPath: string): string[] {
-		return ["-p", promptPath];
+		return ["run", "--file", promptPath, "--", "Execute the task in the attached file"];
 	}
 
 	getName(): string {


### PR DESCRIPTION
## Summary

- Fixes OpenCode backend not working with tmux sessions
- Output is now visible when attaching to tmux session

## Problem

The OpenCodeAdapter was using `-p promptPath` which is invalid. OpenCode CLI doesn't have a `-p` flag - it uses `opencode run` subcommand with `--file` for file attachments.

## Solution

Change from:
```
opencode -p .agent/PROMPT.md
```

To:
```
opencode run --file .agent/PROMPT.md -- "Execute the task in the attached file"
```

## Testing

- Verified `opencode run` executes and output is visible in tmux
- All 308 tests pass