### PR TITLE
feat: load config file in CLI

### DIFF
--- a/orch.yml
+++ b/orch.yml
@@ -1,40 +1,16 @@
-version: "1.0"
+backend: opencode
+auto: false
+create_pr: false
+max_iterations: 100
+preset: simple
 
-backend:
-  type: claude
-  
-loop:
-  max_iterations: 100
-  completion_promise: "LOOP_COMPLETE"
-  idle_timeout_secs: 1800
+worktree:
+  enabled: true
+  base_dir: ".worktrees"
+  copy_files:
+    - ".env"
 
-hats:
-  planner:
-    triggers: ["task.start"]
-    publishes: ["plan.ready"]
-    
-  builder:
-    triggers: ["plan.ready", "tests.failing"]
-    publishes: ["code.written"]
-    
-  tester:
-    triggers: ["code.written"]
-    publishes: ["tests.passing", "tests.failing"]
-    
-  reviewer:
-    triggers: ["tests.passing"]
-    publishes: ["review.approved", "review.rejected"]
-
-gates:
-  after_plan: true
-  after_implementation: false
-  before_pr: true
-
-quality:
-  min_score: 8
-  auto_approve_above: 9
-
-state:
-  use_github_labels: true
-  use_scratchpad: true
-  scratchpad_path: ".agent/scratchpad.md"
+session:
+  manager: auto
+  prefix: orch
+  capture_interval: 500


### PR DESCRIPTION
## Summary

- CLI now reads `orch.yml` configuration file
- Config values serve as defaults, CLI options override them
- Updated `orch.yml` to v3 schema format

## Changes

### CLI (`src/cli.ts`)
- Import `loadConfig` from `./core/config`
- Add `mergeOptionsWithConfig()` to merge CLI options with config
- Add `-c, --config <path>` option for custom config path
- Remove hardcoded defaults from CLI options (now come from config)

### Config (`orch.yml`)
- Updated to v3 schema format:
  - `backend: opencode` (was `backend.type: claude`)
  - `session.manager`, `worktree.base_dir` etc.

## Usage

```yaml
# orch.yml
backend: opencode
max_iterations: 50
session:
  manager: tmux
worktree:
  base_dir: ".worktrees"
```

```bash
# Uses config defaults
orch run --issue 4

# CLI overrides config
orch run --issue 4 --backend claude
```

## Testing

- All 308 tests pass
- Verified backend selection from config file works