### PR TITLE
feat(cli): WorktreeManager CLI統合

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -107,9 +107,16 @@ describe("CLI Commands", () => {
 
 			expect(worktreesCmd).toBeDefined();
 		});
+
+		it("should have description for listing worktrees", async () => {
+			const program = await createTestProgram();
+			const worktreesCmd = program.commands.find((cmd) => cmd.name() === "worktrees");
+
+			expect(worktreesCmd?.description()).toContain("worktree");
+		});
 	});
 
-	describe("orch worktree remove", () => {
+	describe("orch worktree", () => {
 		it("should register worktree command with remove subcommand", async () => {
 			const program = await createTestProgram();
 			const worktreeCmd = program.commands.find((cmd) => cmd.name() === "worktree");
@@ -118,6 +125,26 @@ describe("CLI Commands", () => {
 
 			const removeCmd = worktreeCmd?.commands.find((cmd) => cmd.name() === "remove");
 			expect(removeCmd).toBeDefined();
+		});
+
+		it("should have remove subcommand with --force option", async () => {
+			const program = await createTestProgram();
+			const worktreeCmd = program.commands.find((cmd) => cmd.name() === "worktree");
+			const removeCmd = worktreeCmd?.commands.find((cmd) => cmd.name() === "remove");
+
+			expect(removeCmd).toBeDefined();
+			const optionNames = removeCmd?.options.map((opt) => opt.long ?? opt.short) ?? [];
+			expect(optionNames).toContain("--force");
+		});
+
+		it("should have create subcommand", async () => {
+			const program = await createTestProgram();
+			const worktreeCmd = program.commands.find((cmd) => cmd.name() === "worktree");
+
+			expect(worktreeCmd).toBeDefined();
+
+			const createCmd = worktreeCmd?.commands.find((cmd) => cmd.name() === "create");
+			expect(createCmd).toBeDefined();
 		});
 	});
 


### PR DESCRIPTION
## 概要

Issue #158 の対応として、WorktreeManagerをCLIコマンドに統合しました。

## 変更内容

### `src/cli.ts`
- `WorktreeManager`, `WorktreeNotFoundError`, `WorktreeRunningError` をインポート
- `createWorktreeManager()` ヘルパー関数を追加（デフォルト設定でインスタンス生成）
- `formatWorktreeTable()` 関数を追加（worktree一覧をテーブル形式で表示）

### 実装したコマンド

| コマンド | 説明 |
|---------|------|
| `orch worktrees` | 全worktree一覧を表示 |
| `orch worktree create <issue>` | 指定Issueのworktreeを作成 |
| `orch worktree remove <issue> [--force]` | 指定Issueのworktreeを削除 |

### `src/cli.test.ts`
- `orch worktrees` コマンドの存在・説明テスト
- `orch worktree create` サブコマンドのテスト
- `orch worktree remove --force` オプションのテスト

## エラーハンドリング

- `WorktreeRunningError`: 実行中のworktreeは削除不可
- `WorktreeNotFoundError`: 存在しないworktreeの削除試行

## テスト結果

- 330テスト全通過（+3テスト追加）

Closes #158